### PR TITLE
36 fetch and display memory data

### DIFF
--- a/src/app/api/prisma/location/get-all/route.ts
+++ b/src/app/api/prisma/location/get-all/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { MOCK_LOCATIONS, MOCK_MEMORIES } from '@/lib/mock-data';
+
+export async function GET() {
+  try {
+    // TODO: Replace with real Prisma query once SCRUM-54 is complete:
+    // const locations = await prisma.location.findMany({
+    //   include: { _count: { select: { memories: true } } },
+    //   orderBy: { buildingName: 'asc' },
+    // });
+    const locations = MOCK_LOCATIONS.map((loc) => ({
+      ...loc,
+      _count: {
+        memories: MOCK_MEMORIES.filter((m) => m.locationId === loc.id).length,
+      },
+    }));
+
+    return NextResponse.json({
+      success: true,
+      message: 'Locations fetched successfully',
+      data: locations,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/prisma/location/get-all/route.ts
+++ b/src/app/api/prisma/location/get-all/route.ts
@@ -20,8 +20,13 @@ export async function GET() {
       message: 'Locations fetched successfully',
       data: locations,
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Unable to fetch locations. Please try again.',
+      },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/prisma/memory/create/route.ts
+++ b/src/app/api/prisma/memory/create/route.ts
@@ -8,7 +8,11 @@ export async function POST(request: NextRequest) {
     const result = createMemoryServerSchema.safeParse(body);
     if (!result.success) {
       return NextResponse.json(
-        { error: 'Validation failed', details: result.error.flatten() },
+        {
+          success: false,
+          message: 'Validation failed',
+          details: result.error.flatten(),
+        },
         { status: 400 }
       );
     }
@@ -28,10 +32,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       message: 'Memory created successfully',
-      memory: mockMemory,
+      data: mockMemory,
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+  } catch {
+    return NextResponse.json(
+      { success: false, message: 'Unable to create memory. Please try again.' },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/prisma/memory/create/route.ts
+++ b/src/app/api/prisma/memory/create/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createMemoryServerSchema } from '@/lib/schemas';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const result = createMemoryServerSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: result.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    // TODO: Replace mock with service layer call (e.g. createMemoryService(result.data))
+    const mockMemory = {
+      id: crypto.randomUUID(),
+      ...result.data,
+      mediaURL: null,
+      uploadDate: new Date().toISOString(),
+      isArchived: false,
+      deletedAt: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    return NextResponse.json({
+      success: true,
+      message: 'Memory created successfully',
+      memory: mockMemory,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/prisma/memory/get-by-location/route.ts
+++ b/src/app/api/prisma/memory/get-by-location/route.ts
@@ -15,7 +15,11 @@ export async function GET(request: NextRequest) {
 
     if (!result.success) {
       return NextResponse.json(
-        { error: 'Validation failed', details: result.error.flatten() },
+        {
+          success: false,
+          message: 'Validation failed',
+          details: result.error.flatten(),
+        },
         { status: 400 }
       );
     }
@@ -43,8 +47,13 @@ export async function GET(request: NextRequest) {
       message: 'Memories fetched successfully',
       data: memories,
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Unable to fetch memories. Please try again.',
+      },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/prisma/memory/get-by-location/route.ts
+++ b/src/app/api/prisma/memory/get-by-location/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { MOCK_MEMORIES } from '@/lib/mock-data';
+
+const querySchema = z.object({
+  locationId: z.string().uuid('Invalid location ID'),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const result = querySchema.safeParse({
+      locationId: searchParams.get('locationId'),
+    });
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: result.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    // TODO: Replace mock filter with real Prisma query once SCRUM-54 is complete:
+    // const memories = await prisma.memory.findMany({
+    //   where: {
+    //     locationId: result.data.locationId,
+    //     isArchived: false,
+    //     deletedAt: null,
+    //   },
+    //   include: {
+    //     tags: true,
+    //     location: { select: { id: true, buildingName: true } },
+    //     _count: { select: { votes: true } },
+    //   },
+    //   orderBy: { createdAt: 'desc' },
+    // });
+    const memories = MOCK_MEMORIES.filter(
+      (m) => m.locationId === result.data.locationId
+    );
+
+    return NextResponse.json({
+      success: true,
+      message: 'Memories fetched successfully',
+      data: memories,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/add-memory-modal.tsx
+++ b/src/components/add-memory-modal.tsx
@@ -1,44 +1,517 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { useCreateMemory } from '@/lib/hooks/useCreateMemory';
+import { MOCK_LOCATIONS } from '@/lib/mock-data';
+import {
+  createMemorySchema,
+  type CreateMemoryInput,
+  type MemoryVisibility,
+} from '@/lib/schemas';
+import { Upload, MapPin, FileText, Eye, X, ImageIcon } from 'lucide-react';
+import Image from 'next/image';
 
-type Tab = 'upload' | 'caption' | 'privacy';
+// =============================================================================
+// TYPES
+// =============================================================================
+
+type Step = 'upload' | 'landmark' | 'details' | 'preview';
+
+interface FormData {
+  mediaFile: File | null;
+  mediaPreviewUrl: string | null;
+  locationId: string;
+  title: string;
+  description: string;
+  tags: string[];
+  visibility: MemoryVisibility;
+}
 
 interface AddMemoryModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const STEPS: Step[] = ['upload', 'landmark', 'details', 'preview'];
+
+const STEP_META: Record<Step, { label: string; icon: typeof Upload }> = {
+  upload: { label: 'Upload', icon: Upload },
+  landmark: { label: 'Landmark', icon: MapPin },
+  details: { label: 'Details', icon: FileText },
+  preview: { label: 'Preview', icon: Eye },
+};
+
+const VISIBILITY_OPTIONS: {
+  value: MemoryVisibility;
+  label: string;
+  description: string;
+}[] = [
+  { value: 'PUBLIC', label: 'Public', description: 'Visible to everyone' },
+  {
+    value: 'PROGRAM_ONLY',
+    label: 'Program Only',
+    description: 'Visible to your program',
+  },
+  {
+    value: 'BATCH_ONLY',
+    label: 'Batch Only',
+    description: 'Visible to your batch',
+  },
+  {
+    value: 'PRIVATE',
+    label: 'Private',
+    description: 'Only you can see this',
+  },
+];
+
+const INITIAL_FORM_DATA: FormData = {
+  mediaFile: null,
+  mediaPreviewUrl: null,
+  locationId: '',
+  title: '',
+  description: '',
+  tags: [],
+  visibility: 'PUBLIC',
+};
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
 export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
-  const [currentTab, setCurrentTab] = useState<Tab>('upload');
+  const [currentStep, setCurrentStep] = useState<Step>('upload');
+  const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA);
+  const [tagInput, setTagInput] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const tabs: Tab[] = ['upload', 'caption', 'privacy'];
-  const tabLabels: Record<Tab, string> = {
-    upload: 'Upload Media',
-    caption: 'Add Caption',
-    privacy: 'Privacy',
-  };
+  const { mutate: createMemory, isPending } = useCreateMemory();
 
-  const handleNext = () => {
-    const currentIndex = tabs.indexOf(currentTab);
-    if (currentIndex < tabs.length - 1) {
-      setCurrentTab(tabs[currentIndex + 1]);
+  const currentStepIndex = STEPS.indexOf(currentStep);
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  const updateField = useCallback(
+    <K extends keyof FormData>(key: K, value: FormData[K]) => {
+      setFormData((prev) => ({ ...prev, [key]: value }));
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    },
+    []
+  );
+
+  const selectedLocation = useMemo(
+    () => MOCK_LOCATIONS.find((loc) => loc.id === formData.locationId),
+    [formData.locationId]
+  );
+
+  // ---------------------------------------------------------------------------
+  // File handling
+  // ---------------------------------------------------------------------------
+
+  const handleFileSelect = useCallback(
+    (file: File | undefined) => {
+      if (!file) return;
+
+      if (formData.mediaPreviewUrl) {
+        URL.revokeObjectURL(formData.mediaPreviewUrl);
+      }
+
+      updateField('mediaFile', file);
+      updateField('mediaPreviewUrl', URL.createObjectURL(file));
+    },
+    [formData.mediaPreviewUrl, updateField]
+  );
+
+  const handleRemoveFile = useCallback(() => {
+    if (formData.mediaPreviewUrl) {
+      URL.revokeObjectURL(formData.mediaPreviewUrl);
     }
+    updateField('mediaFile', null);
+    updateField('mediaPreviewUrl', null);
+  }, [formData.mediaPreviewUrl, updateField]);
+
+  // ---------------------------------------------------------------------------
+  // Tag handling
+  // ---------------------------------------------------------------------------
+
+  const handleAddTag = useCallback(() => {
+    const tag = tagInput.trim();
+    if (!tag || formData.tags.includes(tag) || formData.tags.length >= 10)
+      return;
+    updateField('tags', [...formData.tags, tag]);
+    setTagInput('');
+  }, [tagInput, formData.tags, updateField]);
+
+  const handleRemoveTag = useCallback(
+    (tagToRemove: string) => {
+      updateField(
+        'tags',
+        formData.tags.filter((t) => t !== tagToRemove)
+      );
+    },
+    [formData.tags, updateField]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Step validation
+  // ---------------------------------------------------------------------------
+
+  const validateCurrentStep = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (currentStep === 'landmark' && !formData.locationId) {
+      newErrors.locationId = 'Please select a landmark';
+    }
+
+    if (currentStep === 'details') {
+      const result = createMemorySchema.safeParse({
+        title: formData.title,
+        description: formData.description || undefined,
+        visibility: formData.visibility,
+        locationId: formData.locationId,
+        tags: formData.tags.length > 0 ? formData.tags : undefined,
+      });
+
+      if (!result.success) {
+        for (const issue of result.error.issues) {
+          const field = issue.path[0];
+          if (field && typeof field === 'string') {
+            newErrors[field] = issue.message;
+          }
+        }
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [currentStep, formData]);
+
+  // ---------------------------------------------------------------------------
+  // Navigation
+  // ---------------------------------------------------------------------------
+
+  const handleNext = useCallback(() => {
+    if (!validateCurrentStep()) return;
+    if (currentStepIndex < STEPS.length - 1) {
+      setCurrentStep(STEPS[currentStepIndex + 1]);
+    }
+  }, [validateCurrentStep, currentStepIndex]);
+
+  const handleBack = useCallback(() => {
+    if (currentStepIndex > 0) {
+      setCurrentStep(STEPS[currentStepIndex - 1]);
+    }
+  }, [currentStepIndex]);
+
+  const handleCancel = useCallback(() => {
+    onOpenChange(false);
+    setCurrentStep('upload');
+    setFormData(INITIAL_FORM_DATA);
+    setTagInput('');
+    setErrors({});
+  }, [onOpenChange]);
+
+  // ---------------------------------------------------------------------------
+  // Submit
+  // ---------------------------------------------------------------------------
+
+  const handleSubmit = useCallback(() => {
+    // TODO: programBatchId should come from the authenticated user's session
+    const MOCK_PROGRAM_BATCH_ID = '00000000-0000-0000-0000-000000000001';
+
+    const payload: CreateMemoryInput & { programBatchId: string } = {
+      title: formData.title,
+      description: formData.description || undefined,
+      visibility: formData.visibility,
+      locationId: formData.locationId,
+      tags: formData.tags.length > 0 ? formData.tags : undefined,
+      programBatchId: MOCK_PROGRAM_BATCH_ID,
+    };
+
+    createMemory(payload, {
+      onSuccess: () => {
+        handleCancel();
+      },
+    });
+  }, [formData, createMemory, handleCancel]);
+
+  // ---------------------------------------------------------------------------
+  // Step renderers
+  // ---------------------------------------------------------------------------
+
+  const renderUploadStep = () => (
+    <div className="flex flex-col items-center justify-center gap-4">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*,video/*"
+        className="hidden"
+        onChange={(e) => handleFileSelect(e.target.files?.[0])}
+      />
+
+      {formData.mediaPreviewUrl ? (
+        <div className="relative h-48 w-full">
+          <Image
+            src={formData.mediaPreviewUrl}
+            alt="Preview"
+            fill
+            className="rounded-lg object-cover"
+            unoptimized
+          />
+          <button
+            type="button"
+            onClick={handleRemoveFile}
+            className="absolute right-2 top-2 rounded-full bg-black/50 p-1 text-white hover:bg-black/70"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <p className="mt-2 text-center text-xs text-gray-500">
+            {formData.mediaFile?.name}
+          </p>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="flex h-48 w-full flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-gray-300 transition-colors hover:border-skolaroid-blue hover:bg-gray-50"
+        >
+          <ImageIcon className="h-8 w-8 text-gray-400" />
+          <p className="text-sm text-gray-500">Drag and drop your media here</p>
+          <p className="text-xs text-gray-400">or click to browse</p>
+        </button>
+      )}
+    </div>
+  );
+
+  const renderLandmarkStep = () => (
+    <div className="space-y-3">
+      <label className="block text-sm font-medium text-gray-700">
+        Select a Landmark
+      </label>
+      {errors.locationId && (
+        <p className="text-sm text-red-500">{errors.locationId}</p>
+      )}
+      <div className="space-y-2">
+        {MOCK_LOCATIONS.map((location) => (
+          <button
+            key={location.id}
+            type="button"
+            onClick={() => updateField('locationId', location.id)}
+            className={`flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors ${
+              formData.locationId === location.id
+                ? 'border-skolaroid-blue bg-blue-50'
+                : 'border-gray-200 hover:border-gray-300'
+            }`}
+          >
+            <MapPin
+              className={`mt-0.5 h-4 w-4 shrink-0 ${
+                formData.locationId === location.id
+                  ? 'text-skolaroid-blue'
+                  : 'text-gray-400'
+              }`}
+            />
+            <div>
+              <p className="text-sm font-medium text-gray-900">
+                {location.buildingName}
+              </p>
+              {location.description && (
+                <p className="text-xs text-gray-500">{location.description}</p>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  const renderDetailsStep = () => (
+    <div className="space-y-4">
+      {/* Title */}
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">
+          Title <span className="text-red-500">*</span>
+        </label>
+        <Input
+          value={formData.title}
+          onChange={(e) => updateField('title', e.target.value)}
+          placeholder="Give your memory a title"
+          maxLength={255}
+        />
+        {errors.title && <p className="text-sm text-red-500">{errors.title}</p>}
+      </div>
+
+      {/* Description */}
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">
+          Description
+        </label>
+        <textarea
+          value={formData.description}
+          onChange={(e) => updateField('description', e.target.value)}
+          placeholder="Tell the story behind this memory..."
+          className="h-24 w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder-gray-400 focus:border-skolaroid-blue focus:outline-none"
+          maxLength={5000}
+        />
+      </div>
+
+      {/* Tags */}
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">
+          Tags ({formData.tags.length}/10)
+        </label>
+        <div className="flex gap-2">
+          <Input
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAddTag();
+              }
+            }}
+            placeholder="Add a tag and press Enter"
+            maxLength={50}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleAddTag}
+            disabled={!tagInput.trim() || formData.tags.length >= 10}
+          >
+            Add
+          </Button>
+        </div>
+        {formData.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            {formData.tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="gap-1">
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => handleRemoveTag(tag)}
+                  className="ml-0.5 hover:text-red-500"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Visibility */}
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">
+          Privacy
+        </label>
+        <div className="space-y-2">
+          {VISIBILITY_OPTIONS.map((option) => (
+            <label
+              key={option.value}
+              className="flex cursor-pointer items-start gap-3"
+            >
+              <input
+                type="radio"
+                name="visibility"
+                value={option.value}
+                checked={formData.visibility === option.value}
+                onChange={() => updateField('visibility', option.value)}
+                className="mt-0.5 h-4 w-4 text-skolaroid-blue"
+              />
+              <div>
+                <span className="text-sm font-medium text-gray-700">
+                  {option.label}
+                </span>
+                <p className="text-xs text-gray-500">{option.description}</p>
+              </div>
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderPreviewStep = () => (
+    <div className="space-y-4">
+      {/* Media preview */}
+      {formData.mediaPreviewUrl ? (
+        <div className="relative h-32 w-full">
+          <Image
+            src={formData.mediaPreviewUrl}
+            alt="Preview"
+            fill
+            className="rounded-lg object-cover"
+            unoptimized
+          />
+        </div>
+      ) : (
+        <div className="flex h-32 items-center justify-center rounded-lg bg-gray-100 text-sm text-gray-400">
+          No media uploaded
+        </div>
+      )}
+
+      {/* Location */}
+      <div className="flex items-center gap-2 text-sm">
+        <MapPin className="h-4 w-4 text-skolaroid-blue" />
+        <span className="font-medium">
+          {selectedLocation?.buildingName ?? 'No location selected'}
+        </span>
+      </div>
+
+      {/* Title & Description */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900">
+          {formData.title || 'Untitled'}
+        </h3>
+        {formData.description && (
+          <p className="mt-1 text-sm text-gray-600">{formData.description}</p>
+        )}
+      </div>
+
+      {/* Tags */}
+      {formData.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {formData.tags.map((tag) => (
+            <Badge key={tag} variant="secondary">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Visibility */}
+      <Badge variant="outline">
+        {VISIBILITY_OPTIONS.find((v) => v.value === formData.visibility)?.label}
+      </Badge>
+    </div>
+  );
+
+  const STEP_RENDERERS: Record<Step, () => React.ReactNode> = {
+    upload: renderUploadStep,
+    landmark: renderLandmarkStep,
+    details: renderDetailsStep,
+    preview: renderPreviewStep,
   };
 
-  const handleSave = () => {
-    // TODO: Implement save functionality
-    console.log('Saving memory...');
-    onOpenChange(false);
-    setCurrentTab('upload');
-  };
+  // ---------------------------------------------------------------------------
+  // Main render
+  // ---------------------------------------------------------------------------
 
-  const handleCancel = () => {
-    onOpenChange(false);
-    setCurrentTab('upload');
-  };
+  const isLastStep = currentStep === 'preview';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -51,19 +524,30 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
           <div className="flex-1 p-6">
             <DialogTitle className="sr-only">Add Memory</DialogTitle>
             <div className="space-y-4">
-              {tabs.map((tab) => (
-                <button
-                  key={tab}
-                  onClick={() => setCurrentTab(tab)}
-                  className={`block w-full text-left text-sm font-medium transition-colors ${
-                    currentTab === tab
-                      ? 'text-skolaroid-blue'
-                      : 'text-gray-500 hover:text-gray-700'
-                  }`}
-                >
-                  {tabLabels[tab]}
-                </button>
-              ))}
+              {STEPS.map((step, index) => {
+                const meta = STEP_META[step];
+                const Icon = meta.icon;
+                const isActive = currentStep === step;
+                const isAccessible = index <= currentStepIndex;
+
+                return (
+                  <button
+                    key={step}
+                    onClick={() => isAccessible && setCurrentStep(step)}
+                    disabled={!isAccessible}
+                    className={`flex w-full items-center gap-2 text-left text-sm font-medium transition-colors ${
+                      isActive
+                        ? 'text-skolaroid-blue'
+                        : isAccessible
+                          ? 'text-gray-500 hover:text-gray-700'
+                          : 'cursor-not-allowed text-gray-300'
+                    }`}
+                  >
+                    <Icon className="h-4 w-4" />
+                    {meta.label}
+                  </button>
+                );
+              })}
             </div>
           </div>
         </div>
@@ -73,78 +557,35 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
 
         {/* Content Area */}
         <div className="flex flex-1 flex-col">
-          {/* Tab Content */}
           <div className="flex-1 overflow-y-auto p-6">
-            {currentTab === 'upload' && (
-              <div className="flex flex-col items-center justify-center gap-4">
-                <div className="flex h-32 w-full items-center justify-center rounded-lg border-2 border-dashed border-gray-300">
-                  <div className="text-center">
-                    <p className="text-sm text-gray-500">
-                      Drag and drop your media here
-                    </p>
-                    <p className="text-xs text-gray-400">or click to browse</p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {currentTab === 'caption' && (
-              <div className="space-y-3">
-                <label className="block text-sm font-medium text-gray-700">
-                  Caption
-                </label>
-                <textarea
-                  placeholder="Add a caption for your memory..."
-                  className="h-32 w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder-gray-400 focus:border-skolaroid-blue focus:outline-none"
-                />
-              </div>
-            )}
-
-            {currentTab === 'privacy' && (
-              <div className="space-y-3">
-                <label className="block text-sm font-medium text-gray-700">
-                  Privacy Settings
-                </label>
-                <div className="space-y-2">
-                  <label className="flex items-center gap-3">
-                    <input
-                      type="radio"
-                      name="privacy"
-                      value="public"
-                      defaultChecked
-                      className="h-4 w-4 text-skolaroid-blue"
-                    />
-                    <span className="text-sm text-gray-700">Public</span>
-                  </label>
-                  <label className="flex items-center gap-3">
-                    <input
-                      type="radio"
-                      name="privacy"
-                      value="private"
-                      className="h-4 w-4 text-skolaroid-blue"
-                    />
-                    <span className="text-sm text-gray-700">Private</span>
-                  </label>
-                </div>
-              </div>
-            )}
+            {STEP_RENDERERS[currentStep]()}
           </div>
 
-          {/* Footer with Buttons */}
-          <div className="flex justify-end gap-3 border-t bg-white px-6 py-4">
-            <Button
-              variant="outline"
-              onClick={handleCancel}
-              className="text-gray-700"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={currentTab === 'privacy' ? handleSave : handleNext}
-              className="bg-skolaroid-blue text-white hover:bg-skolaroid-blue/90"
-            >
-              {currentTab === 'privacy' ? 'Save' : 'Next'}
-            </Button>
+          {/* Footer */}
+          <div className="flex justify-between border-t bg-white px-6 py-4">
+            <div>
+              {currentStepIndex > 0 && (
+                <Button variant="ghost" onClick={handleBack}>
+                  Back
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                onClick={handleCancel}
+                className="text-gray-700"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={isLastStep ? handleSubmit : handleNext}
+                disabled={isPending}
+                className="bg-skolaroid-blue text-white hover:bg-skolaroid-blue/90"
+              >
+                {isPending ? 'Submitting...' : isLastStep ? 'Submit' : 'Next'}
+              </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/src/components/add-memory-modal.tsx
+++ b/src/components/add-memory-modal.tsx
@@ -7,11 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useCreateMemory } from '@/lib/hooks/useCreateMemory';
 import { MOCK_LOCATIONS } from '@/lib/mock-data';
-import {
-  createMemorySchema,
-  type CreateMemoryInput,
-  type MemoryVisibility,
-} from '@/lib/schemas';
+import { createMemorySchema, type MemoryVisibility } from '@/lib/schemas';
 import { Upload, MapPin, FileText, Eye, X, ImageIcon } from 'lucide-react';
 import Image from 'next/image';
 
@@ -230,23 +226,39 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
   // ---------------------------------------------------------------------------
 
   const handleSubmit = useCallback(() => {
-    // TODO: programBatchId should come from the authenticated user's session
-    const MOCK_PROGRAM_BATCH_ID = '00000000-0000-0000-0000-000000000001';
-
-    const payload: CreateMemoryInput & { programBatchId: string } = {
+    // Final validation before submitting
+    const parsed = createMemorySchema.safeParse({
       title: formData.title,
       description: formData.description || undefined,
       visibility: formData.visibility,
       locationId: formData.locationId,
       tags: formData.tags.length > 0 ? formData.tags : undefined,
-      programBatchId: MOCK_PROGRAM_BATCH_ID,
-    };
-
-    createMemory(payload, {
-      onSuccess: () => {
-        handleCancel();
-      },
     });
+
+    if (!parsed.success) {
+      const newErrors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const field = issue.path[0];
+        if (field && typeof field === 'string') {
+          newErrors[field] = issue.message;
+        }
+      }
+      setErrors(newErrors);
+      setCurrentStep('details');
+      return;
+    }
+
+    // TODO: programBatchId should come from the authenticated user's session
+    const MOCK_PROGRAM_BATCH_ID = '00000000-0000-0000-0000-000000000001';
+
+    createMemory(
+      { ...parsed.data, programBatchId: MOCK_PROGRAM_BATCH_ID },
+      {
+        onSuccess: () => {
+          handleCancel();
+        },
+      }
+    );
   }, [formData, createMemory, handleCancel]);
 
   // ---------------------------------------------------------------------------
@@ -290,8 +302,8 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
           className="flex h-48 w-full flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-gray-300 transition-colors hover:border-skolaroid-blue hover:bg-gray-50"
         >
           <ImageIcon className="h-8 w-8 text-gray-400" />
-          <p className="text-sm text-gray-500">Drag and drop your media here</p>
-          <p className="text-xs text-gray-400">or click to browse</p>
+          <p className="text-sm text-gray-500">Click to browse your media</p>
+          <p className="text-xs text-gray-400">Supports images and videos</p>
         </button>
       )}
     </div>
@@ -514,7 +526,13 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
   const isLastStep = currentStep === 'preview';
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) handleCancel();
+        else onOpenChange(true);
+      }}
+    >
       <DialogContent
         className="flex h-[500px] max-w-2xl gap-0 overflow-hidden p-0"
         showCloseButton={false}

--- a/src/components/memory-card.tsx
+++ b/src/components/memory-card.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+// TODO: Update next.config.ts images.remotePatterns when real media URLs
+// (e.g., Supabase storage) are used instead of local placeholders.
+
+import Image from 'next/image';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+interface MemoryCardProps {
+  memory: {
+    id: string;
+    title: string;
+    description?: string | null;
+    mediaURL?: string | null;
+    visibility: string;
+    createdAt: string;
+    tags?: { id: string; name: string }[];
+    location?: { buildingName: string };
+    _count?: { votes: number };
+  };
+}
+
+export function MemoryCard({ memory }: MemoryCardProps) {
+  return (
+    <Card className="overflow-hidden">
+      {memory.mediaURL && (
+        <div className="relative h-48 w-full">
+          <Image
+            src={memory.mediaURL}
+            alt={memory.title}
+            fill
+            className="object-cover"
+          />
+        </div>
+      )}
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-lg">{memory.title}</CardTitle>
+          <Badge variant="secondary" className="shrink-0">
+            {memory.visibility}
+          </Badge>
+        </div>
+        {memory.location && (
+          <CardDescription>{memory.location.buildingName}</CardDescription>
+        )}
+      </CardHeader>
+      {memory.description && (
+        <CardContent>
+          <p className="line-clamp-3 text-sm text-muted-foreground">
+            {memory.description}
+          </p>
+        </CardContent>
+      )}
+      <CardFooter className="justify-between text-xs text-muted-foreground">
+        <div className="flex flex-wrap gap-1">
+          {memory.tags?.map((tag) => (
+            <Badge key={tag.id} variant="outline" className="text-xs">
+              {tag.name}
+            </Badge>
+          ))}
+        </div>
+        {memory._count != null && <span>{memory._count.votes} votes</span>}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/memory-card.tsx
+++ b/src/components/memory-card.tsx
@@ -13,14 +13,21 @@ import {
   CardFooter,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import type { MemoryVisibility } from '@/lib/schemas';
+
+const VISIBILITY_LABELS: Record<MemoryVisibility, string> = {
+  PUBLIC: 'Public',
+  PROGRAM_ONLY: 'Program',
+  BATCH_ONLY: 'Batch',
+  PRIVATE: 'Private',
+};
 
 export interface MemoryCardMemory {
   id: string;
   title: string;
   description?: string | null;
   mediaURL?: string | null;
-  visibility: string;
-  createdAt: string;
+  visibility: MemoryVisibility;
   tags?: { id: string; name: string }[];
   location?: { buildingName: string };
   _count?: { votes: number };
@@ -47,7 +54,7 @@ export function MemoryCard({ memory }: MemoryCardProps) {
         <div className="flex items-start justify-between gap-2">
           <CardTitle className="text-lg">{memory.title}</CardTitle>
           <Badge variant="secondary" className="shrink-0">
-            {memory.visibility}
+            {VISIBILITY_LABELS[memory.visibility]}
           </Badge>
         </div>
         {memory.location && (

--- a/src/components/memory-card.tsx
+++ b/src/components/memory-card.tsx
@@ -14,18 +14,20 @@ import {
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 
+export interface MemoryCardMemory {
+  id: string;
+  title: string;
+  description?: string | null;
+  mediaURL?: string | null;
+  visibility: string;
+  createdAt: string;
+  tags?: { id: string; name: string }[];
+  location?: { buildingName: string };
+  _count?: { votes: number };
+}
+
 interface MemoryCardProps {
-  memory: {
-    id: string;
-    title: string;
-    description?: string | null;
-    mediaURL?: string | null;
-    visibility: string;
-    createdAt: string;
-    tags?: { id: string; name: string }[];
-    location?: { buildingName: string };
-    _count?: { votes: number };
-  };
+  memory: MemoryCardMemory;
 }
 
 export function MemoryCard({ memory }: MemoryCardProps) {

--- a/src/components/memory-list.tsx
+++ b/src/components/memory-list.tsx
@@ -3,7 +3,7 @@
 // TODO: Integrate into map sidebar when landmark click handlers are implemented.
 
 import { useMemoriesByLocation } from '@/lib/hooks/useMemoriesByLocation';
-import { MemoryCard } from '@/components/memory-card';
+import { MemoryCard, type MemoryCardMemory } from '@/components/memory-card';
 
 interface MemoryListProps {
   locationId: string | null;
@@ -50,7 +50,7 @@ export function MemoryList({ locationId, locationName }: MemoryListProps) {
 
   return (
     <div className="grid gap-4 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-      {memories.map((memory: { id: string; [key: string]: unknown }) => (
+      {memories.map((memory: MemoryCardMemory) => (
         <MemoryCard key={memory.id} memory={memory} />
       ))}
     </div>

--- a/src/components/memory-list.tsx
+++ b/src/components/memory-list.tsx
@@ -3,7 +3,7 @@
 // TODO: Integrate into map sidebar when landmark click handlers are implemented.
 
 import { useMemoriesByLocation } from '@/lib/hooks/useMemoriesByLocation';
-import { MemoryCard, type MemoryCardMemory } from '@/components/memory-card';
+import { MemoryCard } from '@/components/memory-card';
 
 interface MemoryListProps {
   locationId: string | null;
@@ -11,7 +11,7 @@ interface MemoryListProps {
 }
 
 export function MemoryList({ locationId, locationName }: MemoryListProps) {
-  const { data, isPending, isError, error } = useMemoriesByLocation(locationId);
+  const { data, isPending, isError } = useMemoriesByLocation(locationId);
 
   if (!locationId) {
     return (
@@ -32,7 +32,7 @@ export function MemoryList({ locationId, locationName }: MemoryListProps) {
   if (isError) {
     return (
       <div className="p-8 text-center text-sm text-red-500">
-        {error?.message ?? 'Failed to load memories'}
+        Failed to load memories. Please try again.
       </div>
     );
   }
@@ -49,8 +49,8 @@ export function MemoryList({ locationId, locationName }: MemoryListProps) {
   }
 
   return (
-    <div className="grid gap-4 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-      {memories.map((memory: MemoryCardMemory) => (
+    <div className="grid gap-4 p-4 md:grid-cols-2 lg:grid-cols-3">
+      {memories.map((memory) => (
         <MemoryCard key={memory.id} memory={memory} />
       ))}
     </div>

--- a/src/components/memory-list.tsx
+++ b/src/components/memory-list.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+// TODO: Integrate into map sidebar when landmark click handlers are implemented.
+
+import { useMemoriesByLocation } from '@/lib/hooks/useMemoriesByLocation';
+import { MemoryCard } from '@/components/memory-card';
+
+interface MemoryListProps {
+  locationId: string | null;
+  locationName?: string;
+}
+
+export function MemoryList({ locationId, locationName }: MemoryListProps) {
+  const { data, isPending, isError, error } = useMemoriesByLocation(locationId);
+
+  if (!locationId) {
+    return (
+      <div className="flex items-center justify-center p-8 text-muted-foreground">
+        Select a landmark to view memories
+      </div>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <div className="flex items-center justify-center p-8 text-muted-foreground">
+        Loading memories...
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-8 text-center text-sm text-red-500">
+        {error?.message ?? 'Failed to load memories'}
+      </div>
+    );
+  }
+
+  const memories = data?.data ?? [];
+
+  if (memories.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 p-8 text-muted-foreground">
+        <p>No memories yet{locationName ? ` for ${locationName}` : ''}</p>
+        <p className="text-xs">Be the first to add one!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+      {memories.map((memory: { id: string; [key: string]: unknown }) => (
+        <MemoryCard key={memory.id} memory={memory} />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/hooks/useCreateMemory.ts
+++ b/src/lib/hooks/useCreateMemory.ts
@@ -1,27 +1,31 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { CreateMemoryInput } from '@/lib/schemas';
-
-interface CreateMemoryPayload extends CreateMemoryInput {
-  programBatchId: string;
-}
+import type { CreateMemoryServerInput } from '@/lib/schemas';
 
 export function useCreateMemory() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: CreateMemoryPayload) => {
+    retry: 1,
+    mutationFn: async (data: CreateMemoryServerInput) => {
       const res = await fetch('/api/prisma/memory/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
       if (!res.ok) {
-        const error = await res.json();
-        throw new Error(error.error ?? 'Failed to create memory');
+        const errorBody = await res.json().catch(() => ({}));
+        throw new Error(
+          (errorBody as { message?: string }).message ??
+            'Failed to create memory'
+        );
       }
-      return res.json();
+      return res.json() as Promise<{
+        success: boolean;
+        message: string;
+        data: Record<string, unknown>;
+      }>;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['memories'] });

--- a/src/lib/hooks/useCreateMemory.ts
+++ b/src/lib/hooks/useCreateMemory.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { CreateMemoryInput } from '@/lib/schemas';
+
+interface CreateMemoryPayload extends CreateMemoryInput {
+  programBatchId: string;
+}
+
+export function useCreateMemory() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: CreateMemoryPayload) => {
+      const res = await fetch('/api/prisma/memory/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error ?? 'Failed to create memory');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['memories'] });
+    },
+  });
+}

--- a/src/lib/hooks/useLocations.ts
+++ b/src/lib/hooks/useLocations.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export function useLocations() {
+  return useQuery({
+    queryKey: ['locations'],
+    queryFn: async () => {
+      const res = await fetch('/api/prisma/location/get-all');
+      if (!res.ok) throw new Error('Failed to fetch locations');
+      return res.json();
+    },
+  });
+}

--- a/src/lib/hooks/useLocations.ts
+++ b/src/lib/hooks/useLocations.ts
@@ -2,13 +2,30 @@
 
 import { useQuery } from '@tanstack/react-query';
 
+interface LocationWithCount {
+  id: string;
+  buildingName: string;
+  description: string | null;
+  latitude: number;
+  longitude: number;
+  _count: { memories: number };
+}
+
+interface LocationsResponse {
+  success: boolean;
+  message: string;
+  data: LocationWithCount[];
+}
+
 export function useLocations() {
   return useQuery({
     queryKey: ['locations'],
     queryFn: async () => {
       const res = await fetch('/api/prisma/location/get-all');
       if (!res.ok) throw new Error('Failed to fetch locations');
-      return res.json();
+      return res.json() as Promise<LocationsResponse>;
     },
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
   });
 }

--- a/src/lib/hooks/useMemoriesByLocation.ts
+++ b/src/lib/hooks/useMemoriesByLocation.ts
@@ -1,17 +1,26 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import type { MemoryCardMemory } from '@/components/memory-card';
+
+interface MemoriesByLocationResponse {
+  success: boolean;
+  message: string;
+  data: MemoryCardMemory[];
+}
 
 export function useMemoriesByLocation(locationId: string | null) {
   return useQuery({
     queryKey: ['memories', 'by-location', locationId],
     queryFn: async () => {
       const res = await fetch(
-        `/api/prisma/memory/get-by-location?locationId=${locationId}`
+        `/api/prisma/memory/get-by-location?locationId=${encodeURIComponent(locationId!)}`
       );
       if (!res.ok) throw new Error('Failed to fetch memories');
-      return res.json();
+      return res.json() as Promise<MemoriesByLocationResponse>;
     },
     enabled: !!locationId,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
   });
 }

--- a/src/lib/hooks/useMemoriesByLocation.ts
+++ b/src/lib/hooks/useMemoriesByLocation.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export function useMemoriesByLocation(locationId: string | null) {
+  return useQuery({
+    queryKey: ['memories', 'by-location', locationId],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/prisma/memory/get-by-location?locationId=${locationId}`
+      );
+      if (!res.ok) throw new Error('Failed to fetch memories');
+      return res.json();
+    },
+    enabled: !!locationId,
+  });
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,0 +1,43 @@
+/**
+ * Mock location data for the landmark selector.
+ * TODO: Replace with a useLocations() hook that fetches from the API.
+ */
+export const MOCK_LOCATIONS = [
+  {
+    id: '00000000-0000-0000-0000-000000000001',
+    buildingName: 'Oblation Plaza',
+    description: 'Main entrance and iconic landmark',
+    latitude: 14.6537,
+    longitude: 121.0685,
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000002',
+    buildingName: 'UP Main Library',
+    description: 'Gonzalez Hall — central library',
+    latitude: 14.6544,
+    longitude: 121.0703,
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000003',
+    buildingName: 'AS Steps',
+    description: 'College of Arts and Sciences amphitheater steps',
+    latitude: 14.6539,
+    longitude: 121.0711,
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000004',
+    buildingName: 'Sunken Garden',
+    description: 'Open field for events and gatherings',
+    latitude: 14.6546,
+    longitude: 121.0695,
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000005',
+    buildingName: 'College of Engineering',
+    description: 'Melchor Hall and surrounding buildings',
+    latitude: 14.6556,
+    longitude: 121.0662,
+  },
+] as const;
+
+export type MockLocation = (typeof MOCK_LOCATIONS)[number];

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -41,3 +41,260 @@ export const MOCK_LOCATIONS = [
 ] as const;
 
 export type MockLocation = (typeof MOCK_LOCATIONS)[number];
+
+/**
+ * Mock memory data for landmark memory display.
+ * Spread unevenly across locations to test empty/populated states.
+ *
+ * TODO: Remove mock data once SCRUM-54 database integration is complete.
+ * These will be replaced by real Prisma queries in the API routes.
+ */
+export const MOCK_MEMORIES = [
+  // --- Oblation Plaza (3 memories) ---
+  {
+    id: '10000000-0000-0000-0000-000000000001',
+    title: 'Freshman Welcome at Oblation Plaza',
+    description:
+      'The first day of classes — batch 2024 gathered at the Oblation for the traditional photo.',
+    mediaURL: '/temporary_map.png',
+    uploadDate: '2024-08-15T08:00:00.000Z',
+    visibility: 'PUBLIC' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000001',
+    createdAt: '2024-08-15T08:00:00.000Z',
+    updatedAt: '2024-08-15T08:00:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000001',
+      buildingName: 'Oblation Plaza',
+    },
+    tags: [
+      {
+        id: '30000000-0000-0000-0000-000000000001',
+        name: 'freshman',
+        slug: 'freshman',
+      },
+      {
+        id: '30000000-0000-0000-0000-000000000002',
+        name: 'batch-2024',
+        slug: 'batch-2024',
+      },
+    ],
+    _count: { votes: 12 },
+  },
+  {
+    id: '10000000-0000-0000-0000-000000000002',
+    title: 'Oblation Run 2024',
+    description:
+      'Annual tradition — the brave ones sprint across the plaza at dawn.',
+    mediaURL: '/temporary_map.png',
+    uploadDate: '2024-12-01T05:30:00.000Z',
+    visibility: 'PUBLIC' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000001',
+    createdAt: '2024-12-01T05:30:00.000Z',
+    updatedAt: '2024-12-01T05:30:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000001',
+      buildingName: 'Oblation Plaza',
+    },
+    tags: [
+      {
+        id: '30000000-0000-0000-0000-000000000003',
+        name: 'tradition',
+        slug: 'tradition',
+      },
+    ],
+    _count: { votes: 24 },
+  },
+  {
+    id: '10000000-0000-0000-0000-000000000003',
+    title: 'Sunset at the Oblation',
+    description: null,
+    mediaURL: '/temporary_map.png',
+    uploadDate: '2025-01-10T17:45:00.000Z',
+    visibility: 'PROGRAM_ONLY' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000001',
+    createdAt: '2025-01-10T17:45:00.000Z',
+    updatedAt: '2025-01-10T17:45:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000001',
+      buildingName: 'Oblation Plaza',
+    },
+    tags: [],
+    _count: { votes: 3 },
+  },
+
+  // --- UP Main Library (2 memories) ---
+  {
+    id: '10000000-0000-0000-0000-000000000004',
+    title: 'Finals Week Study Session',
+    description:
+      'The library was packed during finals — every table claimed by 7 AM.',
+    mediaURL: '/temporary_map.png',
+    uploadDate: '2024-12-15T07:00:00.000Z',
+    visibility: 'PUBLIC' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000002',
+    createdAt: '2024-12-15T07:00:00.000Z',
+    updatedAt: '2024-12-15T07:00:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000002',
+      buildingName: 'UP Main Library',
+    },
+    tags: [
+      {
+        id: '30000000-0000-0000-0000-000000000004',
+        name: 'academics',
+        slug: 'academics',
+      },
+      {
+        id: '30000000-0000-0000-0000-000000000005',
+        name: 'finals',
+        slug: 'finals',
+      },
+    ],
+    _count: { votes: 8 },
+  },
+  {
+    id: '10000000-0000-0000-0000-000000000005',
+    title: 'Library Book Fair',
+    description: 'Annual book fair hosted in the Gonzalez Hall lobby.',
+    mediaURL: null,
+    uploadDate: '2025-02-10T10:00:00.000Z',
+    visibility: 'PUBLIC' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000002',
+    createdAt: '2025-02-10T10:00:00.000Z',
+    updatedAt: '2025-02-10T10:00:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000002',
+      buildingName: 'UP Main Library',
+    },
+    tags: [
+      {
+        id: '30000000-0000-0000-0000-000000000006',
+        name: 'event',
+        slug: 'event',
+      },
+    ],
+    _count: { votes: 6 },
+  },
+
+  // --- AS Steps (2 memories) ---
+  {
+    id: '10000000-0000-0000-0000-000000000006',
+    title: 'Acoustic Night at AS Steps',
+    description:
+      'Student bands played until midnight — one of the best nights on campus.',
+    mediaURL: '/temporary_map.png',
+    uploadDate: '2024-11-20T19:00:00.000Z',
+    visibility: 'PUBLIC' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000003',
+    createdAt: '2024-11-20T19:00:00.000Z',
+    updatedAt: '2024-11-20T19:00:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000003',
+      buildingName: 'AS Steps',
+    },
+    tags: [
+      {
+        id: '30000000-0000-0000-0000-000000000007',
+        name: 'music',
+        slug: 'music',
+      },
+      {
+        id: '30000000-0000-0000-0000-000000000008',
+        name: 'night-event',
+        slug: 'night-event',
+      },
+    ],
+    _count: { votes: 15 },
+  },
+  {
+    id: '10000000-0000-0000-0000-000000000007',
+    title: 'Protest Rally for Academic Freedom',
+    description: 'Students gathered at the steps for a peaceful rally.',
+    mediaURL: '/temporary_map.png',
+    uploadDate: '2025-01-25T14:00:00.000Z',
+    visibility: 'BATCH_ONLY' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000003',
+    createdAt: '2025-01-25T14:00:00.000Z',
+    updatedAt: '2025-01-25T14:00:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000003',
+      buildingName: 'AS Steps',
+    },
+    tags: [
+      {
+        id: '30000000-0000-0000-0000-000000000009',
+        name: 'activism',
+        slug: 'activism',
+      },
+    ],
+    _count: { votes: 20 },
+  },
+
+  // --- Sunken Garden (1 memory) ---
+  {
+    id: '10000000-0000-0000-0000-000000000008',
+    title: 'Lantern Parade 2024',
+    description:
+      'The entire garden lit up with handmade lanterns — a beautiful sight every December.',
+    mediaURL: '/temporary_map.png',
+    uploadDate: '2024-12-18T18:00:00.000Z',
+    visibility: 'PUBLIC' as const,
+    isArchived: false,
+    deletedAt: null,
+    creatorId: null,
+    programBatchId: '20000000-0000-0000-0000-000000000001',
+    locationId: '00000000-0000-0000-0000-000000000004',
+    createdAt: '2024-12-18T18:00:00.000Z',
+    updatedAt: '2024-12-18T18:00:00.000Z',
+    location: {
+      id: '00000000-0000-0000-0000-000000000004',
+      buildingName: 'Sunken Garden',
+    },
+    tags: [
+      {
+        id: '30000000-0000-0000-0000-000000000003',
+        name: 'tradition',
+        slug: 'tradition',
+      },
+      {
+        id: '30000000-0000-0000-0000-000000000006',
+        name: 'event',
+        slug: 'event',
+      },
+    ],
+    _count: { votes: 31 },
+  },
+
+  // --- College of Engineering (0 memories) ---
+  // Intentionally empty to test the "no memories" empty state
+];
+
+export type MockMemory = (typeof MOCK_MEMORIES)[number];

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -47,11 +47,15 @@ export const createMemorySchema = z.object({
     .string()
     .min(1, 'Title is required')
     .max(255, 'Title must be 255 characters or less'),
-  description: z.string().max(5000, 'Description is too long').optional(),
+  description: z
+    .string()
+    .trim()
+    .max(5000, 'Description is too long')
+    .optional(),
   visibility: memoryVisibilityEnum.default('PUBLIC'),
   locationId: z.string().uuid('Invalid location'),
   tags: z
-    .array(z.string().min(1).max(50))
+    .array(z.string().trim().min(1).max(50))
     .max(10, 'Maximum 10 tags')
     .optional(),
 });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -30,8 +30,48 @@ export const forgotPasswordSchema = z.object({
   email: z.string().email('Invalid email address'),
 });
 
-// Type exports for use in components/API routes
+// ============================================================================
+// MEMORY SCHEMAS
+// ============================================================================
+
+export const memoryVisibilityEnum = z.enum([
+  'PUBLIC',
+  'PROGRAM_ONLY',
+  'BATCH_ONLY',
+  'PRIVATE',
+]);
+
+/** Schema for creating a memory — used by the form (client-side). */
+export const createMemorySchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Title is required')
+    .max(255, 'Title must be 255 characters or less'),
+  description: z.string().max(5000, 'Description is too long').optional(),
+  visibility: memoryVisibilityEnum.default('PUBLIC'),
+  locationId: z.string().uuid('Invalid location'),
+  tags: z
+    .array(z.string().min(1).max(50))
+    .max(10, 'Maximum 10 tags')
+    .optional(),
+});
+
+/** Server-side schema — same fields sent over the wire (no File objects). */
+export const createMemoryServerSchema = createMemorySchema.extend({
+  programBatchId: z.string().uuid('Invalid program batch'),
+});
+
+// ============================================================================
+// TYPE EXPORTS
+// ============================================================================
+
+// Auth types
 export type LoginInput = z.infer<typeof loginSchema>;
 export type SignUpInput = z.infer<typeof signUpSchema>;
 export type UpdatePasswordInput = z.infer<typeof updatePasswordSchema>;
 export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
+
+// Memory types
+export type MemoryVisibility = z.infer<typeof memoryVisibilityEnum>;
+export type CreateMemoryInput = z.infer<typeof createMemorySchema>;
+export type CreateMemoryServerInput = z.infer<typeof createMemoryServerSchema>;


### PR DESCRIPTION
## Summary

Implements the full memory creation, fetching, and display workflow with mock data. Subsumes PR #45 (`45-build-memory-submission-form`) which is closed in favour of this unified PR.

**Memory submission (from PR #45):**

- **Zod schemas** in `schemas.ts` — `createMemorySchema` (client) and `createMemoryServerSchema` (server) with `memoryVisibilityEnum`. Description and tags use `.trim()` at the schema level to reject whitespace-only input.
- **API route** at `POST /api/prisma/memory/create` — Zod `safeParse`, standardised `{ success, message, data }` response envelope, generic error messages (no raw error leaks).
- **`useCreateMemory` hook** — `useMutation` with `retry: 1`, typed response, imports `CreateMemoryServerInput` directly from schemas (no duplicate local type). Invalidates `['memories']` on success.
- **`AddMemoryModal`** — 4-step form (Upload, Landmark, Details, Preview) with sidebar navigation. Final `safeParse` validation before submit prevents corrupted data reaching the API. Form state resets on Escape/overlay close, not just the Cancel button.

**Memory display (new in this PR):**

- **Mock data** in `mock-data.ts` — 5 UP Diliman landmarks (`MOCK_LOCATIONS`) and 8 memories (`MOCK_MEMORIES`) spread unevenly (3/2/2/1/0) to exercise empty, single-item, and multi-item states.
- **API route** at `GET /api/prisma/memory/get-by-location` — Zod-validated `locationId` query param, filters mock data. Commented-out Prisma query ready for SCRUM-54 swap.
- **API route** at `GET /api/prisma/location/get-all` — returns all locations with computed `_count.memories`. Same mock-now/Prisma-later pattern.
- **`useMemoriesByLocation` hook** — `useQuery` keyed on `['memories', 'by-location', locationId]` with `enabled: !!locationId`, `staleTime: 5min`, `retry: 1`, typed response, `encodeURIComponent` on the query param. Key prefix aligns with `useCreateMemory`'s invalidation so submit auto-refetches the list.
- **`useLocations` hook** — `useQuery` keyed on `['locations']` with `staleTime: 5min`, `retry: 1`, typed response interface.
- **`MemoryCard` component** — presentational. Renders image, title, human-readable visibility label (via `VISIBILITY_LABELS` map using `MemoryVisibility` enum), location name, description (`line-clamp-3`), tags, and vote count. Exports `MemoryCardMemory` interface for cross-component typing.
- **`MemoryList` component** — owns data fetching via `useMemoriesByLocation`, renders a responsive `MemoryCard` grid (1→2→3 columns). Handles all four states: no landmark selected, loading, error (static user-friendly message), and empty.

### What's intentionally deferred

- Map sidebar integration (`MemoryList` accepts `locationId: string | null` and is ready to drop in, but no landmark click handlers exist yet on the map)
- Real Prisma queries (all routes use mock data pending SCRUM-54)
- Auth-aware visibility filtering (PUBLIC vs PROGRAM_ONLY vs BATCH_ONLY vs PRIVATE — mock data includes all variants but the API doesn't filter by session yet)
- Auth guard on `POST /api/prisma/memory/create` (no session check yet)
- Media URLs pointing to real storage (placeholders used; `next.config.ts` will need `images.remotePatterns` updated for Supabase storage)
- `programBatchId` hardcoded to mock UUID (needs session integration)

### Relation to prior work

This PR subsumes `45-build-memory-submission-form` (PR #45 is closed). All 5 original commits from #45 are included here, plus 7 display/fetch commits and 6 code-review fix commits that standardise API response shapes, add typed hook responses, enforce `staleTime`/`retry`, and harden the modal UX.