### PR TITLE
41 custom tags to memories

### DIFF
--- a/src/app/api/prisma/memory/create/route.ts
+++ b/src/app/api/prisma/memory/create/route.ts
@@ -10,8 +10,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          message: 'Validation failed',
-          details: result.error.flatten(),
+          message: result.error.issues[0]?.message ?? 'Validation failed',
         },
         { status: 400 }
       );

--- a/src/app/api/prisma/memory/get-by-location/route.ts
+++ b/src/app/api/prisma/memory/get-by-location/route.ts
@@ -1,15 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
+import { memoriesByLocationQuerySchema } from '@/lib/schemas';
 import { MOCK_MEMORIES } from '@/lib/mock-data';
-
-const querySchema = z.object({
-  locationId: z.string().uuid('Invalid location ID'),
-});
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    const result = querySchema.safeParse({
+    const result = memoriesByLocationQuerySchema.safeParse({
       locationId: searchParams.get('locationId'),
     });
 
@@ -17,8 +13,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          message: 'Validation failed',
-          details: result.error.flatten(),
+          message: result.error.issues[0]?.message ?? 'Validation failed',
         },
         { status: 400 }
       );

--- a/src/app/api/prisma/memory/update-tags/route.ts
+++ b/src/app/api/prisma/memory/update-tags/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { updateMemoryTagsSchema } from '@/lib/schemas';
+import { slugify } from '@/lib/slugify';
+
+export async function PATCH(request: Request) {
+  try {
+    const body: unknown = await request.json();
+    const result = updateMemoryTagsSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: result.error.issues[0]?.message ?? 'Validation failed',
+        },
+        { status: 400 }
+      );
+    }
+
+    // TODO: Replace with real Prisma query once SCRUM-54 is complete:
+    // const updated = await prisma.memory.update({
+    //   where: { id: result.data.memoryId },
+    //   data: {
+    //     tags: {
+    //       set: [],
+    //       connectOrCreate: result.data.tags.map((name) => ({
+    //         where: { slug: slugify(name) },
+    //         create: { name, slug: slugify(name) },
+    //       })),
+    //     },
+    //   },
+    //   include: { tags: true },
+    // });
+    const mockTags = result.data.tags.map((name) => ({
+      id: crypto.randomUUID(),
+      name,
+      slug: slugify(name),
+    }));
+
+    return NextResponse.json({
+      success: true,
+      message: 'Tags updated successfully',
+      data: { memoryId: result.data.memoryId, tags: mockTags },
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Unable to update tags. Please try again.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/prisma/memory/update-tags/route.ts
+++ b/src/app/api/prisma/memory/update-tags/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { updateMemoryTagsSchema } from '@/lib/schemas';
 import { slugify } from '@/lib/slugify';
 
-export async function PATCH(request: Request) {
+export async function PATCH(request: NextRequest) {
   try {
     const body: unknown = await request.json();
     const result = updateMemoryTagsSchema.safeParse(body);

--- a/src/app/api/prisma/tag/get-all/route.ts
+++ b/src/app/api/prisma/tag/get-all/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { MOCK_TAGS } from '@/lib/mock-data';
+
+export async function GET() {
+  try {
+    // TODO: Replace with real Prisma query once SCRUM-54 is complete:
+    // const tags = await prisma.tag.findMany({
+    //   orderBy: { name: 'asc' },
+    // });
+    const tags = [...MOCK_TAGS].sort((a, b) => a.name.localeCompare(b.name));
+
+    return NextResponse.json({
+      success: true,
+      message: 'Tags fetched successfully',
+      data: tags,
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Unable to fetch tags. Please try again.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/add-memory-modal.tsx
+++ b/src/components/add-memory-modal.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useCreateMemory } from '@/lib/hooks/useCreateMemory';
+import { useTags } from '@/lib/hooks/useTags';
 import { MOCK_LOCATIONS } from '@/lib/mock-data';
 import { createMemorySchema, type MemoryVisibility } from '@/lib/schemas';
 import { Upload, MapPin, FileText, Eye, X, ImageIcon } from 'lucide-react';
@@ -86,6 +87,7 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
   const [currentStep, setCurrentStep] = useState<Step>('upload');
   const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA);
   const [tagInput, setTagInput] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -113,6 +115,21 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
     () => MOCK_LOCATIONS.find((loc) => loc.id === formData.locationId),
     [formData.locationId]
   );
+
+  const { data: tagsData } = useTags();
+
+  const filteredSuggestions = useMemo(() => {
+    const query = tagInput.trim().toLowerCase();
+    if (!query) return [];
+    const allTags = tagsData?.data ?? [];
+    return allTags
+      .filter(
+        (t) =>
+          t.name.toLowerCase().includes(query) &&
+          !formData.tags.includes(t.name)
+      )
+      .slice(0, 5);
+  }, [tagInput, tagsData?.data, formData.tags]);
 
   // ---------------------------------------------------------------------------
   // File handling
@@ -385,27 +402,54 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
         <label className="block text-sm font-medium text-gray-700">
           Tags ({formData.tags.length}/10)
         </label>
-        <div className="flex gap-2">
-          <Input
-            value={tagInput}
-            onChange={(e) => setTagInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleAddTag();
-              }
-            }}
-            placeholder="Add a tag and press Enter"
-            maxLength={50}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleAddTag}
-            disabled={!tagInput.trim() || formData.tags.length >= 10}
-          >
-            Add
-          </Button>
+        <div className="relative">
+          <div className="flex gap-2">
+            <Input
+              value={tagInput}
+              onChange={(e) => {
+                setTagInput(e.target.value);
+                setShowSuggestions(true);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddTag();
+                  setShowSuggestions(false);
+                }
+              }}
+              onFocus={() => setShowSuggestions(true)}
+              onBlur={() => setShowSuggestions(false)}
+              placeholder="Add a tag and press Enter"
+              maxLength={50}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleAddTag}
+              disabled={!tagInput.trim() || formData.tags.length >= 10}
+            >
+              Add
+            </Button>
+          </div>
+          {showSuggestions && filteredSuggestions.length > 0 && (
+            <div className="absolute z-10 mt-1 w-full rounded-md border bg-white shadow-lg">
+              {filteredSuggestions.map((tag) => (
+                <button
+                  key={tag.id}
+                  type="button"
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    updateField('tags', [...formData.tags, tag.name]);
+                    setTagInput('');
+                    setShowSuggestions(false);
+                  }}
+                >
+                  {tag.name}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
         {formData.tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5 pt-1">

--- a/src/components/add-memory-modal.tsx
+++ b/src/components/add-memory-modal.tsx
@@ -1,14 +1,19 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { TagInput } from '@/components/tag-input';
 import { useCreateMemory } from '@/lib/hooks/useCreateMemory';
-import { useTags } from '@/lib/hooks/useTags';
 import { MOCK_LOCATIONS } from '@/lib/mock-data';
-import { createMemorySchema, type MemoryVisibility } from '@/lib/schemas';
+import {
+  createMemorySchema,
+  VISIBILITY_LABELS,
+  MAX_TAGS,
+  type MemoryVisibility,
+} from '@/lib/schemas';
 import { Upload, MapPin, FileText, Eye, X, ImageIcon } from 'lucide-react';
 import Image from 'next/image';
 
@@ -51,7 +56,11 @@ const VISIBILITY_OPTIONS: {
   label: string;
   description: string;
 }[] = [
-  { value: 'PUBLIC', label: 'Public', description: 'Visible to everyone' },
+  {
+    value: 'PUBLIC',
+    label: VISIBILITY_LABELS.PUBLIC,
+    description: 'Visible to everyone',
+  },
   {
     value: 'PROGRAM_ONLY',
     label: 'Program Only',
@@ -64,7 +73,7 @@ const VISIBILITY_OPTIONS: {
   },
   {
     value: 'PRIVATE',
-    label: 'Private',
+    label: VISIBILITY_LABELS.PRIVATE,
     description: 'Only you can see this',
   },
 ];
@@ -86,14 +95,26 @@ const INITIAL_FORM_DATA: FormData = {
 export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
   const [currentStep, setCurrentStep] = useState<Step>('upload');
   const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA);
-  const [tagInput, setTagInput] = useState('');
-  const [showSuggestions, setShowSuggestions] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { mutate: createMemory, isPending } = useCreateMemory();
 
   const currentStepIndex = STEPS.indexOf(currentStep);
+
+  // ---------------------------------------------------------------------------
+  // Cleanup Object URLs on unmount to prevent memory leaks
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    return () => {
+      if (formData.mediaPreviewUrl) {
+        URL.revokeObjectURL(formData.mediaPreviewUrl);
+      }
+    };
+    // Only run cleanup on unmount — intentionally excluding formData.mediaPreviewUrl
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Helpers
@@ -116,20 +137,23 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
     [formData.locationId]
   );
 
-  const { data: tagsData } = useTags();
-
-  const filteredSuggestions = useMemo(() => {
-    const query = tagInput.trim().toLowerCase();
-    if (!query) return [];
-    const allTags = tagsData?.data ?? [];
-    return allTags
-      .filter(
-        (t) =>
-          t.name.toLowerCase().includes(query) &&
-          !formData.tags.includes(t.name)
-      )
-      .slice(0, 5);
-  }, [tagInput, tagsData?.data, formData.tags]);
+  /** Build the input shape expected by createMemorySchema from current form state. */
+  const buildSchemaInput = useCallback(
+    () => ({
+      title: formData.title,
+      description: formData.description || undefined,
+      visibility: formData.visibility,
+      locationId: formData.locationId,
+      tags: formData.tags.length > 0 ? formData.tags : undefined,
+    }),
+    [
+      formData.title,
+      formData.description,
+      formData.visibility,
+      formData.locationId,
+      formData.tags,
+    ]
+  );
 
   // ---------------------------------------------------------------------------
   // File handling
@@ -143,10 +167,20 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
         URL.revokeObjectURL(formData.mediaPreviewUrl);
       }
 
-      updateField('mediaFile', file);
-      updateField('mediaPreviewUrl', URL.createObjectURL(file));
+      const previewUrl = URL.createObjectURL(file);
+      setFormData((prev) => ({
+        ...prev,
+        mediaFile: file,
+        mediaPreviewUrl: previewUrl,
+      }));
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next['mediaFile'];
+        delete next['mediaPreviewUrl'];
+        return next;
+      });
     },
-    [formData.mediaPreviewUrl, updateField]
+    [formData.mediaPreviewUrl]
   );
 
   const handleRemoveFile = useCallback(() => {
@@ -156,28 +190,6 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
     updateField('mediaFile', null);
     updateField('mediaPreviewUrl', null);
   }, [formData.mediaPreviewUrl, updateField]);
-
-  // ---------------------------------------------------------------------------
-  // Tag handling
-  // ---------------------------------------------------------------------------
-
-  const handleAddTag = useCallback(() => {
-    const tag = tagInput.trim();
-    if (!tag || formData.tags.includes(tag) || formData.tags.length >= 10)
-      return;
-    updateField('tags', [...formData.tags, tag]);
-    setTagInput('');
-  }, [tagInput, formData.tags, updateField]);
-
-  const handleRemoveTag = useCallback(
-    (tagToRemove: string) => {
-      updateField(
-        'tags',
-        formData.tags.filter((t) => t !== tagToRemove)
-      );
-    },
-    [formData.tags, updateField]
-  );
 
   // ---------------------------------------------------------------------------
   // Step validation
@@ -191,13 +203,7 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
     }
 
     if (currentStep === 'details') {
-      const result = createMemorySchema.safeParse({
-        title: formData.title,
-        description: formData.description || undefined,
-        visibility: formData.visibility,
-        locationId: formData.locationId,
-        tags: formData.tags.length > 0 ? formData.tags : undefined,
-      });
+      const result = createMemorySchema.safeParse(buildSchemaInput());
 
       if (!result.success) {
         for (const issue of result.error.issues) {
@@ -211,7 +217,7 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
 
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
-  }, [currentStep, formData]);
+  }, [currentStep, formData.locationId, buildSchemaInput]);
 
   // ---------------------------------------------------------------------------
   // Navigation
@@ -231,26 +237,21 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
   }, [currentStepIndex]);
 
   const handleCancel = useCallback(() => {
+    if (formData.mediaPreviewUrl) {
+      URL.revokeObjectURL(formData.mediaPreviewUrl);
+    }
     onOpenChange(false);
     setCurrentStep('upload');
     setFormData(INITIAL_FORM_DATA);
-    setTagInput('');
     setErrors({});
-  }, [onOpenChange]);
+  }, [onOpenChange, formData.mediaPreviewUrl]);
 
   // ---------------------------------------------------------------------------
   // Submit
   // ---------------------------------------------------------------------------
 
   const handleSubmit = useCallback(() => {
-    // Final validation before submitting
-    const parsed = createMemorySchema.safeParse({
-      title: formData.title,
-      description: formData.description || undefined,
-      visibility: formData.visibility,
-      locationId: formData.locationId,
-      tags: formData.tags.length > 0 ? formData.tags : undefined,
-    });
+    const parsed = createMemorySchema.safeParse(buildSchemaInput());
 
     if (!parsed.success) {
       const newErrors: Record<string, string> = {};
@@ -276,7 +277,7 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
         },
       }
     );
-  }, [formData, createMemory, handleCancel]);
+  }, [buildSchemaInput, createMemory, handleCancel]);
 
   // ---------------------------------------------------------------------------
   // Step renderers
@@ -400,73 +401,12 @@ export function AddMemoryModal({ open, onOpenChange }: AddMemoryModalProps) {
       {/* Tags */}
       <div className="space-y-1">
         <label className="block text-sm font-medium text-gray-700">
-          Tags ({formData.tags.length}/10)
+          Tags ({formData.tags.length}/{MAX_TAGS})
         </label>
-        <div className="relative">
-          <div className="flex gap-2">
-            <Input
-              value={tagInput}
-              onChange={(e) => {
-                setTagInput(e.target.value);
-                setShowSuggestions(true);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  handleAddTag();
-                  setShowSuggestions(false);
-                }
-              }}
-              onFocus={() => setShowSuggestions(true)}
-              onBlur={() => setShowSuggestions(false)}
-              placeholder="Add a tag and press Enter"
-              maxLength={50}
-            />
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleAddTag}
-              disabled={!tagInput.trim() || formData.tags.length >= 10}
-            >
-              Add
-            </Button>
-          </div>
-          {showSuggestions && filteredSuggestions.length > 0 && (
-            <div className="absolute z-10 mt-1 w-full rounded-md border bg-white shadow-lg">
-              {filteredSuggestions.map((tag) => (
-                <button
-                  key={tag.id}
-                  type="button"
-                  className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    updateField('tags', [...formData.tags, tag.name]);
-                    setTagInput('');
-                    setShowSuggestions(false);
-                  }}
-                >
-                  {tag.name}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-        {formData.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 pt-1">
-            {formData.tags.map((tag) => (
-              <Badge key={tag} variant="secondary" className="gap-1">
-                {tag}
-                <button
-                  type="button"
-                  onClick={() => handleRemoveTag(tag)}
-                  className="ml-0.5 hover:text-red-500"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </Badge>
-            ))}
-          </div>
-        )}
+        <TagInput
+          tags={formData.tags}
+          onTagsChange={(newTags) => updateField('tags', newTags)}
+        />
       </div>
 
       {/* Visibility */}

--- a/src/components/edit-tags-dialog.tsx
+++ b/src/components/edit-tags-dialog.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { useTags } from '@/lib/hooks/useTags';
+import { useUpdateMemoryTags } from '@/lib/hooks/useUpdateMemoryTags';
+import { X } from 'lucide-react';
+
+interface EditTagsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  memory: {
+    id: string;
+    title: string;
+    tags?: { id: string; name: string }[];
+  };
+}
+
+export function EditTagsDialog({
+  open,
+  onOpenChange,
+  memory,
+}: EditTagsDialogProps) {
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const { data: tagsData } = useTags();
+  const { mutate: updateTags, isPending } = useUpdateMemoryTags();
+
+  // Reset state when dialog opens with a (potentially different) memory
+  useEffect(() => {
+    if (open) {
+      setTags(memory.tags?.map((t) => t.name) ?? []);
+      setTagInput('');
+      setShowSuggestions(false);
+    }
+  }, [open, memory.id, memory.tags]);
+
+  const filteredSuggestions = useMemo(() => {
+    const query = tagInput.trim().toLowerCase();
+    if (!query) return [];
+    const allTags = tagsData?.data ?? [];
+    return allTags
+      .filter(
+        (t) => t.name.toLowerCase().includes(query) && !tags.includes(t.name)
+      )
+      .slice(0, 5);
+  }, [tagInput, tagsData?.data, tags]);
+
+  const handleAddTag = () => {
+    const tag = tagInput.trim();
+    if (!tag || tags.includes(tag) || tags.length >= 10) return;
+    setTags((prev) => [...prev, tag]);
+    setTagInput('');
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags((prev) => prev.filter((t) => t !== tagToRemove));
+  };
+
+  const handleSave = () => {
+    updateTags(
+      { memoryId: memory.id, tags },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Tags</DialogTitle>
+          <DialogDescription className="truncate">
+            {memory.title}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          {/* Tag input with autocomplete */}
+          <div className="relative">
+            <div className="flex gap-2">
+              <Input
+                value={tagInput}
+                onChange={(e) => {
+                  setTagInput(e.target.value);
+                  setShowSuggestions(true);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddTag();
+                    setShowSuggestions(false);
+                  }
+                }}
+                onFocus={() => setShowSuggestions(true)}
+                onBlur={() => setShowSuggestions(false)}
+                placeholder="Add a tag and press Enter"
+                maxLength={50}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleAddTag}
+                disabled={!tagInput.trim() || tags.length >= 10}
+              >
+                Add
+              </Button>
+            </div>
+            {showSuggestions && filteredSuggestions.length > 0 && (
+              <div className="absolute z-10 mt-1 w-full rounded-md border bg-white shadow-lg">
+                {filteredSuggestions.map((tag) => (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setTags((prev) => [...prev, tag.name]);
+                      setTagInput('');
+                      setShowSuggestions(false);
+                    }}
+                  >
+                    {tag.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Tag count */}
+          <p className="text-xs text-muted-foreground">{tags.length}/10 tags</p>
+
+          {/* Current tags */}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="gap-1">
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveTag(tag)}
+                    className="ml-0.5 hover:text-red-500"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={isPending}
+            className="bg-skolaroid-blue text-white hover:bg-skolaroid-blue/90"
+          >
+            {isPending ? 'Saving...' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/edit-tags-dialog.tsx
+++ b/src/components/edit-tags-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -10,11 +10,9 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { useTags } from '@/lib/hooks/useTags';
+import { TagInput } from '@/components/tag-input';
 import { useUpdateMemoryTags } from '@/lib/hooks/useUpdateMemoryTags';
-import { X } from 'lucide-react';
+import { MAX_TAGS } from '@/lib/schemas';
 
 interface EditTagsDialogProps {
   open: boolean;
@@ -32,49 +30,28 @@ export function EditTagsDialog({
   memory,
 }: EditTagsDialogProps) {
   const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState('');
-  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const { data: tagsData } = useTags();
   const { mutate: updateTags, isPending } = useUpdateMemoryTags();
 
   // Reset state when dialog opens with a (potentially different) memory
   useEffect(() => {
     if (open) {
       setTags(memory.tags?.map((t) => t.name) ?? []);
-      setTagInput('');
-      setShowSuggestions(false);
+      setError(null);
     }
   }, [open, memory.id, memory.tags]);
 
-  const filteredSuggestions = useMemo(() => {
-    const query = tagInput.trim().toLowerCase();
-    if (!query) return [];
-    const allTags = tagsData?.data ?? [];
-    return allTags
-      .filter(
-        (t) => t.name.toLowerCase().includes(query) && !tags.includes(t.name)
-      )
-      .slice(0, 5);
-  }, [tagInput, tagsData?.data, tags]);
-
-  const handleAddTag = () => {
-    const tag = tagInput.trim();
-    if (!tag || tags.includes(tag) || tags.length >= 10) return;
-    setTags((prev) => [...prev, tag]);
-    setTagInput('');
-  };
-
-  const handleRemoveTag = (tagToRemove: string) => {
-    setTags((prev) => prev.filter((t) => t !== tagToRemove));
-  };
-
   const handleSave = () => {
+    setError(null);
     updateTags(
       { memoryId: memory.id, tags },
       {
         onSuccess: () => {
           onOpenChange(false);
+        },
+        onError: (err) => {
+          setError(err.message);
         },
       }
     );
@@ -91,77 +68,15 @@ export function EditTagsDialog({
         </DialogHeader>
 
         <div className="space-y-3 py-2">
-          {/* Tag input with autocomplete */}
-          <div className="relative">
-            <div className="flex gap-2">
-              <Input
-                value={tagInput}
-                onChange={(e) => {
-                  setTagInput(e.target.value);
-                  setShowSuggestions(true);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    handleAddTag();
-                    setShowSuggestions(false);
-                  }
-                }}
-                onFocus={() => setShowSuggestions(true)}
-                onBlur={() => setShowSuggestions(false)}
-                placeholder="Add a tag and press Enter"
-                maxLength={50}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleAddTag}
-                disabled={!tagInput.trim() || tags.length >= 10}
-              >
-                Add
-              </Button>
-            </div>
-            {showSuggestions && filteredSuggestions.length > 0 && (
-              <div className="absolute z-10 mt-1 w-full rounded-md border bg-white shadow-lg">
-                {filteredSuggestions.map((tag) => (
-                  <button
-                    key={tag.id}
-                    type="button"
-                    className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      setTags((prev) => [...prev, tag.name]);
-                      setTagInput('');
-                      setShowSuggestions(false);
-                    }}
-                  >
-                    {tag.name}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
+          <TagInput tags={tags} onTagsChange={setTags} />
 
           {/* Tag count */}
-          <p className="text-xs text-muted-foreground">{tags.length}/10 tags</p>
+          <p className="text-xs text-muted-foreground">
+            {tags.length}/{MAX_TAGS} tags
+          </p>
 
-          {/* Current tags */}
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5">
-              {tags.map((tag) => (
-                <Badge key={tag} variant="secondary" className="gap-1">
-                  {tag}
-                  <button
-                    type="button"
-                    onClick={() => handleRemoveTag(tag)}
-                    className="ml-0.5 hover:text-red-500"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </Badge>
-              ))}
-            </div>
-          )}
+          {/* Error message */}
+          {error && <p className="text-sm text-red-500">{error}</p>}
         </div>
 
         <DialogFooter>

--- a/src/components/memory-card.tsx
+++ b/src/components/memory-card.tsx
@@ -3,6 +3,7 @@
 // TODO: Update next.config.ts images.remotePatterns when real media URLs
 // (e.g., Supabase storage) are used instead of local placeholders.
 
+import { useState } from 'react';
 import Image from 'next/image';
 import {
   Card,
@@ -13,6 +14,8 @@ import {
   CardFooter,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { EditTagsDialog } from '@/components/edit-tags-dialog';
+import { Pencil } from 'lucide-react';
 import type { MemoryVisibility } from '@/lib/schemas';
 
 const VISIBILITY_LABELS: Record<MemoryVisibility, string> = {
@@ -38,46 +41,65 @@ interface MemoryCardProps {
 }
 
 export function MemoryCard({ memory }: MemoryCardProps) {
+  const [editTagsOpen, setEditTagsOpen] = useState(false);
+
   return (
-    <Card className="overflow-hidden">
-      {memory.mediaURL && (
-        <div className="relative h-48 w-full">
-          <Image
-            src={memory.mediaURL}
-            alt={memory.title}
-            fill
-            className="object-cover"
-          />
-        </div>
-      )}
-      <CardHeader>
-        <div className="flex items-start justify-between gap-2">
-          <CardTitle className="text-lg">{memory.title}</CardTitle>
-          <Badge variant="secondary" className="shrink-0">
-            {VISIBILITY_LABELS[memory.visibility]}
-          </Badge>
-        </div>
-        {memory.location && (
-          <CardDescription>{memory.location.buildingName}</CardDescription>
+    <>
+      <Card className="overflow-hidden">
+        {memory.mediaURL && (
+          <div className="relative h-48 w-full">
+            <Image
+              src={memory.mediaURL}
+              alt={memory.title}
+              fill
+              className="object-cover"
+            />
+          </div>
         )}
-      </CardHeader>
-      {memory.description && (
-        <CardContent>
-          <p className="line-clamp-3 text-sm text-muted-foreground">
-            {memory.description}
-          </p>
-        </CardContent>
-      )}
-      <CardFooter className="justify-between text-xs text-muted-foreground">
-        <div className="flex flex-wrap gap-1">
-          {memory.tags?.map((tag) => (
-            <Badge key={tag.id} variant="outline" className="text-xs">
-              {tag.name}
+        <CardHeader>
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="text-lg">{memory.title}</CardTitle>
+            <Badge variant="secondary" className="shrink-0">
+              {VISIBILITY_LABELS[memory.visibility]}
             </Badge>
-          ))}
-        </div>
-        {memory._count != null && <span>{memory._count.votes} votes</span>}
-      </CardFooter>
-    </Card>
+          </div>
+          {memory.location && (
+            <CardDescription>{memory.location.buildingName}</CardDescription>
+          )}
+        </CardHeader>
+        {memory.description && (
+          <CardContent>
+            <p className="line-clamp-3 text-sm text-muted-foreground">
+              {memory.description}
+            </p>
+          </CardContent>
+        )}
+        <CardFooter className="justify-between text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-1">
+            {memory.tags?.map((tag) => (
+              <Badge key={tag.id} variant="outline" className="text-xs">
+                {tag.name}
+              </Badge>
+            ))}
+            {/* TODO: Only show when current user owns this memory (requires SCRUM-54 auth) */}
+            <button
+              type="button"
+              onClick={() => setEditTagsOpen(true)}
+              className="ml-1 text-muted-foreground hover:text-skolaroid-blue"
+              aria-label="Edit tags"
+            >
+              <Pencil className="h-3 w-3" />
+            </button>
+          </div>
+          {memory._count != null && <span>{memory._count.votes} votes</span>}
+        </CardFooter>
+      </Card>
+
+      <EditTagsDialog
+        open={editTagsOpen}
+        onOpenChange={setEditTagsOpen}
+        memory={memory}
+      />
+    </>
   );
 }

--- a/src/components/memory-card.tsx
+++ b/src/components/memory-card.tsx
@@ -16,28 +16,10 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { EditTagsDialog } from '@/components/edit-tags-dialog';
 import { Pencil } from 'lucide-react';
-import type { MemoryVisibility } from '@/lib/schemas';
-
-const VISIBILITY_LABELS: Record<MemoryVisibility, string> = {
-  PUBLIC: 'Public',
-  PROGRAM_ONLY: 'Program',
-  BATCH_ONLY: 'Batch',
-  PRIVATE: 'Private',
-};
-
-export interface MemoryCardMemory {
-  id: string;
-  title: string;
-  description?: string | null;
-  mediaURL?: string | null;
-  visibility: MemoryVisibility;
-  tags?: { id: string; name: string }[];
-  location?: { buildingName: string };
-  _count?: { votes: number };
-}
+import { VISIBILITY_LABELS, type MemoryWithRelations } from '@/lib/schemas';
 
 interface MemoryCardProps {
-  memory: MemoryCardMemory;
+  memory: MemoryWithRelations;
 }
 
 export function MemoryCard({ memory }: MemoryCardProps) {

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useTags } from '@/lib/hooks/useTags';
+import { MAX_TAGS, MAX_TAG_SUGGESTIONS } from '@/lib/schemas';
+import { X } from 'lucide-react';
+
+interface TagInputProps {
+  tags: string[];
+  onTagsChange: (tags: string[]) => void;
+}
+
+export function TagInput({ tags, onTagsChange }: TagInputProps) {
+  const [tagInput, setTagInput] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const { data: tagsData } = useTags();
+
+  const filteredSuggestions = useMemo(() => {
+    const query = tagInput.trim().toLowerCase();
+    if (!query) return [];
+    const allTags = tagsData?.data ?? [];
+    return allTags
+      .filter(
+        (t) => t.name.toLowerCase().includes(query) && !tags.includes(t.name)
+      )
+      .slice(0, MAX_TAG_SUGGESTIONS);
+  }, [tagInput, tagsData?.data, tags]);
+
+  const handleAddTag = () => {
+    const tag = tagInput.trim();
+    if (!tag || tags.includes(tag) || tags.length >= MAX_TAGS) return;
+    onTagsChange([...tags, tag]);
+    setTagInput('');
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    onTagsChange(tags.filter((t) => t !== tagToRemove));
+  };
+
+  const handleSelectSuggestion = (name: string) => {
+    onTagsChange([...tags, name]);
+    setTagInput('');
+    setShowSuggestions(false);
+  };
+
+  return (
+    <div className="space-y-1">
+      <div className="relative">
+        <div className="flex gap-2">
+          <Input
+            value={tagInput}
+            onChange={(e) => {
+              setTagInput(e.target.value);
+              setShowSuggestions(true);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAddTag();
+                setShowSuggestions(false);
+              }
+            }}
+            onFocus={() => setShowSuggestions(true)}
+            onBlur={() => setShowSuggestions(false)}
+            placeholder="Add a tag and press Enter"
+            maxLength={50}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleAddTag}
+            disabled={!tagInput.trim() || tags.length >= MAX_TAGS}
+          >
+            Add
+          </Button>
+        </div>
+        {showSuggestions && filteredSuggestions.length > 0 && (
+          <div className="absolute z-10 mt-1 w-full rounded-md border bg-white shadow-lg">
+            {filteredSuggestions.map((tag) => (
+              <button
+                key={tag.id}
+                type="button"
+                className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleSelectSuggestion(tag.name);
+                }}
+              >
+                {tag.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 pt-1">
+          {tags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="gap-1">
+              {tag}
+              <button
+                type="button"
+                onClick={() => handleRemoveTag(tag)}
+                className="ml-0.5 hover:text-red-500"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/hooks/useCreateMemory.ts
+++ b/src/lib/hooks/useCreateMemory.ts
@@ -1,7 +1,16 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { CreateMemoryServerInput } from '@/lib/schemas';
+import type {
+  CreateMemoryServerInput,
+  MemoryWithRelations,
+} from '@/lib/schemas';
+
+interface CreateMemoryResponse {
+  success: boolean;
+  message: string;
+  data: MemoryWithRelations;
+}
 
 export function useCreateMemory() {
   const queryClient = useQueryClient();
@@ -21,11 +30,7 @@ export function useCreateMemory() {
             'Failed to create memory'
         );
       }
-      return res.json() as Promise<{
-        success: boolean;
-        message: string;
-        data: Record<string, unknown>;
-      }>;
+      return res.json() as Promise<CreateMemoryResponse>;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['memories'] });

--- a/src/lib/hooks/useMemoriesByLocation.ts
+++ b/src/lib/hooks/useMemoriesByLocation.ts
@@ -1,12 +1,12 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import type { MemoryCardMemory } from '@/components/memory-card';
+import type { MemoryWithRelations } from '@/lib/schemas';
 
 interface MemoriesByLocationResponse {
   success: boolean;
   message: string;
-  data: MemoryCardMemory[];
+  data: MemoryWithRelations[];
 }
 
 export function useMemoriesByLocation(locationId: string | null) {

--- a/src/lib/hooks/useTags.ts
+++ b/src/lib/hooks/useTags.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+interface Tag {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface TagsResponse {
+  success: boolean;
+  message: string;
+  data: Tag[];
+}
+
+export function useTags() {
+  return useQuery({
+    queryKey: ['tags'],
+    queryFn: async () => {
+      const res = await fetch('/api/prisma/tag/get-all');
+      if (!res.ok) throw new Error('Failed to fetch tags');
+      return res.json() as Promise<TagsResponse>;
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/src/lib/hooks/useUpdateMemoryTags.ts
+++ b/src/lib/hooks/useUpdateMemoryTags.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { UpdateMemoryTagsInput } from '@/lib/schemas';
+
+interface UpdateMemoryTagsResponse {
+  success: boolean;
+  message: string;
+  data: {
+    memoryId: string;
+    tags: { id: string; name: string; slug: string }[];
+  };
+}
+
+export function useUpdateMemoryTags() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    retry: 1,
+    mutationFn: async (data: UpdateMemoryTagsInput) => {
+      const res = await fetch('/api/prisma/memory/update-tags', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const errorBody = await res.json().catch(() => ({}));
+        throw new Error(
+          (errorBody as { message?: string }).message ?? 'Failed to update tags'
+        );
+      }
+      return res.json() as Promise<UpdateMemoryTagsResponse>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['memories'] });
+      queryClient.invalidateQueries({ queryKey: ['tags'] });
+    },
+  });
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -298,3 +298,77 @@ export const MOCK_MEMORIES = [
 ];
 
 export type MockMemory = (typeof MOCK_MEMORIES)[number];
+
+/**
+ * Mock tag data for autocomplete and tag API routes.
+ * Extracted from MOCK_MEMORIES for standalone access.
+ *
+ * TODO: Remove once SCRUM-54 database integration is complete.
+ */
+export const MOCK_TAGS = [
+  {
+    id: '30000000-0000-0000-0000-000000000001',
+    name: 'freshman',
+    slug: 'freshman',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000002',
+    name: 'batch-2024',
+    slug: 'batch-2024',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000003',
+    name: 'tradition',
+    slug: 'tradition',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000004',
+    name: 'academics',
+    slug: 'academics',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000005',
+    name: 'finals',
+    slug: 'finals',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000006',
+    name: 'event',
+    slug: 'event',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000007',
+    name: 'music',
+    slug: 'music',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000008',
+    name: 'night-event',
+    slug: 'night-event',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+  {
+    id: '30000000-0000-0000-0000-000000000009',
+    name: 'activism',
+    slug: 'activism',
+    createdAt: '2024-08-01T00:00:00.000Z',
+    updatedAt: '2024-08-01T00:00:00.000Z',
+  },
+] as const;
+
+export type MockTag = (typeof MOCK_TAGS)[number];

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -65,6 +65,12 @@ export const createMemoryServerSchema = createMemorySchema.extend({
   programBatchId: z.string().uuid('Invalid program batch'),
 });
 
+/** Schema for updating tags on an existing memory. */
+export const updateMemoryTagsSchema = z.object({
+  memoryId: z.string().uuid('Invalid memory ID'),
+  tags: z.array(z.string().trim().min(1).max(50)).max(10, 'Maximum 10 tags'),
+});
+
 // ============================================================================
 // TYPE EXPORTS
 // ============================================================================
@@ -79,3 +85,4 @@ export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
 export type MemoryVisibility = z.infer<typeof memoryVisibilityEnum>;
 export type CreateMemoryInput = z.infer<typeof createMemorySchema>;
 export type CreateMemoryServerInput = z.infer<typeof createMemoryServerSchema>;
+export type UpdateMemoryTagsInput = z.infer<typeof updateMemoryTagsSchema>;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -31,6 +31,13 @@ export const forgotPasswordSchema = z.object({
 });
 
 // ============================================================================
+// MEMORY CONSTANTS
+// ============================================================================
+
+export const MAX_TAGS = 10;
+export const MAX_TAG_SUGGESTIONS = 5;
+
+// ============================================================================
 // MEMORY SCHEMAS
 // ============================================================================
 
@@ -45,6 +52,7 @@ export const memoryVisibilityEnum = z.enum([
 export const createMemorySchema = z.object({
   title: z
     .string()
+    .trim()
     .min(1, 'Title is required')
     .max(255, 'Title must be 255 characters or less'),
   description: z
@@ -56,7 +64,7 @@ export const createMemorySchema = z.object({
   locationId: z.string().uuid('Invalid location'),
   tags: z
     .array(z.string().trim().min(1).max(50))
-    .max(10, 'Maximum 10 tags')
+    .max(MAX_TAGS, 'Maximum 10 tags')
     .optional(),
 });
 
@@ -68,21 +76,54 @@ export const createMemoryServerSchema = createMemorySchema.extend({
 /** Schema for updating tags on an existing memory. */
 export const updateMemoryTagsSchema = z.object({
   memoryId: z.string().uuid('Invalid memory ID'),
-  tags: z.array(z.string().trim().min(1).max(50)).max(10, 'Maximum 10 tags'),
+  tags: z
+    .array(z.string().trim().min(1).max(50))
+    .max(MAX_TAGS, 'Maximum 10 tags'),
+});
+
+/** Schema for querying memories by location. */
+export const memoriesByLocationQuerySchema = z.object({
+  locationId: z.string().uuid('Invalid location ID'),
 });
 
 // ============================================================================
-// TYPE EXPORTS
+// MEMORY TYPE EXPORTS
 // ============================================================================
 
-// Auth types
-export type LoginInput = z.infer<typeof loginSchema>;
-export type SignUpInput = z.infer<typeof signUpSchema>;
-export type UpdatePasswordInput = z.infer<typeof updatePasswordSchema>;
-export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
-
-// Memory types
 export type MemoryVisibility = z.infer<typeof memoryVisibilityEnum>;
 export type CreateMemoryInput = z.infer<typeof createMemorySchema>;
 export type CreateMemoryServerInput = z.infer<typeof createMemoryServerSchema>;
 export type UpdateMemoryTagsInput = z.infer<typeof updateMemoryTagsSchema>;
+
+// ============================================================================
+// SHARED TYPES
+// ============================================================================
+
+/** Shape returned by API for a memory with relations. Used by hooks and components. */
+export interface MemoryWithRelations {
+  id: string;
+  title: string;
+  description?: string | null;
+  mediaURL?: string | null;
+  visibility: MemoryVisibility;
+  tags?: { id: string; name: string }[];
+  location?: { buildingName: string };
+  _count?: { votes: number };
+}
+
+/** Visibility label mapping for display. */
+export const VISIBILITY_LABELS: Record<MemoryVisibility, string> = {
+  PUBLIC: 'Public',
+  PROGRAM_ONLY: 'Program',
+  BATCH_ONLY: 'Batch',
+  PRIVATE: 'Private',
+};
+
+// ============================================================================
+// AUTH TYPE EXPORTS
+// ============================================================================
+
+export type LoginInput = z.infer<typeof loginSchema>;
+export type SignUpInput = z.infer<typeof signUpSchema>;
+export type UpdatePasswordInput = z.infer<typeof updatePasswordSchema>;
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -1,0 +1,10 @@
+/** Convert a tag name to a URL-friendly slug. */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '') // remove non-word chars except spaces/hyphens
+    .replace(/[\s_]+/g, '-') // spaces/underscores to hyphens
+    .replace(/-+/g, '-') // collapse consecutive hyphens
+    .replace(/^-|-$/g, ''); // trim leading/trailing hyphens
+}


### PR DESCRIPTION
## Summary

Implements tag management for memories — autocomplete on creation, editing tags on existing memories, and the supporting API/schema/hook infrastructure. 

**Tag infrastructure:**

- **Mock data** in `mock-data.ts` — `MOCK_TAGS` array (9 tags extracted from existing `MOCK_MEMORIES`) for use by the tag API route and autocomplete.
- **`slugify` utility** in `slugify.ts` — generates URL-friendly tag slugs server-side.
- **Zod schemas** in `schemas.ts` — `updateMemoryTagsSchema` (memoryId UUID + tags array, max 10, each trimmed, max 50 chars), `memoriesByLocationQuerySchema` (extracted from inline route definition), `MemoryWithRelations` interface and `VISIBILITY_LABELS` map moved here to fix inverted hook→component type dependency. `MAX_TAGS` and `MAX_TAG_SUGGESTIONS` constants exported. Title field now uses `.trim()` to reject whitespace-only titles.

**Tag autocomplete on memory creation:**

- **API route** at `GET /api/prisma/tag/get-all` — returns all mock tags sorted alphabetically. Mirrors the `location/get-all` pattern with TODO for real Prisma query.
- **`useTags` hook** — `useQuery` keyed on `['tags']` with `staleTime: 5min`, `retry: 1`, typed response. Mirrors `useLocations` pattern.
- **`AddMemoryModal` integration** — `useTags` hook powers a dropdown of matching existing tags as the user types. Suggestions filtered client-side, limited to 5, exclude already-selected tags. Uses `onMouseDown` to prevent blur race.

**Tag editing on existing memories:**

- **API route** at `PATCH /api/prisma/memory/update-tags` — validates input with `updateMemoryTagsSchema`, returns mock tag objects with generated slugs. Includes TODO with real Prisma `connectOrCreate` query pattern.
- **`useUpdateMemoryTags` hook** — `useMutation` that invalidates `['memories']` on success.
- **`EditTagsDialog` component** — tag input with autocomplete and save functionality. Integrated into `MemoryCard` via a pencil icon button in the footer.

**Shared `TagInput` component:**

- **`TagInput`** extracted from duplicated autocomplete logic in `AddMemoryModal` and `EditTagsDialog` (~60 lines deduplicated). Handles suggestion filtering, keyboard navigation, and tag add/remove.

**Code-review fixes (3 commits):**

- Standardize `NextRequest` usage across all routes with request bodies
- Validation errors now use first Zod issue message consistently
- `useCreateMemory` gets typed `CreateMemoryResponse` interface; `MemoryCard` uses shared `MemoryWithRelations` type from schemas instead of component-layer type
- `memoriesByLocationQuerySchema` imported from `schemas.ts` instead of inline definition in route
- Object URL memory leak fixed in `handleCancel` with `useEffect` cleanup
- `buildSchemaInput` helper extracted to deduplicate `safeParse` mapping in modal

### What's intentionally deferred

- Real Prisma queries for tag routes (all routes use mock data pending SCRUM-54)
- Ownership check on edit-tags (anyone can edit any memory's tags; deferred to SCRUM-54 auth integration)
- Tag deletion/management UI (admin-level tag CRUD)
- Tag-based filtering/search on the gallery or map views

### Relation to prior work

Builds on top of the memory creation and display infrastructure from PR #36. Reuses the same patterns: Zod `safeParse` validation, `{ success, message, data }` response envelope, `useQuery`/`useMutation` hooks with typed responses, and mock-now/Prisma-later API routes.