### PR TITLE
Scrum 59 memory engagement

### DIFF
--- a/src/app/api/prisma/memory/vote/status/route.ts
+++ b/src/app/api/prisma/memory/vote/status/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import { voteStatusQuerySchema } from '@/lib/schemas';
+
+export async function GET(request: NextRequest) {
+  try {
+    // ── 1. Validate query params ───────────────────────────────────────────
+    const { searchParams } = new URL(request.url);
+    const parsed = voteStatusQuerySchema.safeParse({
+      memoryId: searchParams.get('memoryId'),
+    });
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? 'Validation failed',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { memoryId } = parsed.data;
+
+    // ── 2. Vote count — public data, always returned ───────────────────────
+    const voteCount = await prisma.memoryVote.count({ where: { memoryId } });
+
+    // ── 3. Resolve userId (optional — hasVoted falls back to false) ────────
+    let hasVoted = false;
+
+    const supabase = await createClient();
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+
+    let resolvedUserId: string | null = null;
+
+    if (authUser) {
+      const dbUser = await prisma.user.findUnique({
+        where: { id: authUser.id },
+        select: { id: true },
+      });
+      resolvedUserId = dbUser?.id ?? null;
+    } else if (process.env.NODE_ENV === 'development') {
+      // Dev seed-user fallback
+      const seedUser = await prisma.user.findUnique({
+        where: { email: 'seed@skolaroid.dev' },
+        select: { id: true },
+      });
+      resolvedUserId = seedUser?.id ?? null;
+    }
+
+    if (resolvedUserId) {
+      const vote = await prisma.memoryVote.findUnique({
+        where: { memoryId_userId: { memoryId, userId: resolvedUserId } },
+        select: { id: true },
+      });
+      hasVoted = !!vote;
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: { hasVoted, voteCount },
+    });
+  } catch (err) {
+    console.error('[vote/status] unexpected error:', err);
+    return NextResponse.json(
+      { success: false, message: 'Unable to fetch vote status.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/prisma/memory/vote/toggle/route.ts
+++ b/src/app/api/prisma/memory/vote/toggle/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import { toggleVoteSchema } from '@/lib/schemas';
+import { toggleVoteService } from '@/services/toggle-vote-service';
+
+/**
+ * Resolves the userId for the request.
+ * - Production:  real Supabase session → check Prisma User row exists.
+ * - Development: same flow, but if there is no session the seed user is used
+ *                as a convenience fallback (never runs in production).
+ *
+ * Returns:
+ *   { userId: string }  — proceed with this user
+ *   { error: NextResponse } — return this response immediately
+ */
+async function resolveUser(
+  isDev: boolean
+): Promise<{ userId: string } | { error: NextResponse }> {
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+
+  if (authUser) {
+    // Real session: verify the Prisma User row exists (FK requirement).
+    const dbUser = await prisma.user.findUnique({
+      where: { id: authUser.id },
+      select: { id: true },
+    });
+
+    if (!dbUser) {
+      return {
+        error: NextResponse.json(
+          {
+            success: false,
+            message: 'Complete onboarding before voting',
+          },
+          { status: 403 }
+        ),
+      };
+    }
+
+    return { userId: dbUser.id };
+  }
+
+  // No session — dev seed-user fallback only.
+  if (isDev) {
+    const seedUser = await prisma.user.findUnique({
+      where: { email: 'seed@skolaroid.dev' },
+      select: { id: true },
+    });
+
+    if (seedUser) return { userId: seedUser.id };
+  }
+
+  return {
+    error: NextResponse.json(
+      { success: false, message: 'Not authenticated' },
+      { status: 401 }
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  const isDev = process.env.NODE_ENV === 'development';
+
+  try {
+    // ── 1. Auth ────────────────────────────────────────────────────────────
+    const resolved = await resolveUser(isDev);
+    if ('error' in resolved) return resolved.error;
+    const { userId } = resolved;
+
+    // ── 2. Validate body ───────────────────────────────────────────────────
+    const body = await request.json();
+    const parsed = toggleVoteSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? 'Validation failed',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { memoryId } = parsed.data;
+
+    // ── 3. Toggle vote ─────────────────────────────────────────────────────
+    const result = await toggleVoteService(memoryId, userId);
+
+    return NextResponse.json({
+      success: true,
+      message: result.voted ? 'Vote added' : 'Vote removed',
+      data: result,
+    });
+  } catch (err) {
+    console.error('[vote/toggle] unexpected error:', err);
+    return NextResponse.json(
+      { success: false, message: 'Unable to process vote. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/prisma/memory/vote/toggle/route.ts
+++ b/src/app/api/prisma/memory/vote/toggle/route.ts
@@ -4,6 +4,31 @@ import { prisma } from '@/lib/prisma';
 import { toggleVoteSchema } from '@/lib/schemas';
 import { toggleVoteService } from '@/services/toggle-vote-service';
 
+// ---------------------------------------------------------------------------
+// In-process rate limiter
+// ---------------------------------------------------------------------------
+// Stores the last toggle timestamp (ms) per "userId:memoryId" pair.
+// Resets on server restart. This is intentionally lightweight — the client
+// already applies a matching 2-second debounce, so only abusive/scripted
+// traffic reaches this guard.
+//
+// TODO (production scale): replace with a Redis/Upstash KV store so the
+// limit is enforced across all serverless instances, not just one process.
+// ---------------------------------------------------------------------------
+const _rateLimitMap = new Map<string, number>();
+const RATE_LIMIT_MS = 2_000;
+
+function isRateLimited(userId: string, memoryId: string): boolean {
+  const key = `${userId}:${memoryId}`;
+  const last = _rateLimitMap.get(key);
+  const now = Date.now();
+
+  if (last !== undefined && now - last < RATE_LIMIT_MS) return true;
+
+  _rateLimitMap.set(key, now);
+  return false;
+}
+
 /**
  * Resolves the userId for the request.
  * - Production:  real Supabase session → check Prisma User row exists.
@@ -89,7 +114,15 @@ export async function POST(request: NextRequest) {
 
     const { memoryId } = parsed.data;
 
-    // ── 3. Toggle vote ─────────────────────────────────────────────────────
+    // ── 3. Rate limit ──────────────────────────────────────────────────────
+    if (isRateLimited(userId, memoryId)) {
+      return NextResponse.json(
+        { success: false, message: 'Too many requests — slow down.' },
+        { status: 429 }
+      );
+    }
+
+    // ── 4. Toggle vote ─────────────────────────────────────────────────────
     const result = await toggleVoteService(memoryId, userId);
 
     return NextResponse.json({

--- a/src/components/account-menu.tsx
+++ b/src/components/account-menu.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+// Account menu component for user profile and logout
 import { User, LogOut } from 'lucide-react';
 import { useUserAuth } from '@/hooks/useUserAuth';
 import {

--- a/src/components/map/ActionBar.tsx
+++ b/src/components/map/ActionBar.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { Copy, Heart, Share } from 'lucide-react';
+import { useState } from 'react';
+import type { MemoryWithRelations } from '@/lib/schemas';
+import { useVoteStatus } from '@/lib/hooks/useVoteStatus';
+import { useToggleVote } from '@/lib/hooks/useToggleVote';
+import { useUserAuth } from '@/hooks/useUserAuth';
+import { formatVoteCount } from '@/lib/utils';
+
+interface ActionBarProps {
+  memory: MemoryWithRelations;
+}
+
+/**
+ * Engagement bar rendered beneath the caption card on every memory page.
+ *
+ * Layout (two rows):
+ *   ♥ 42          ← vote count strip (left-aligned)
+ *   📋  ♥  ↗       ← Copy | Like | Share (centred)
+ */
+export function ActionBar({ memory }: ActionBarProps) {
+  const { isAuthenticated } = useUserAuth();
+  const { data: voteStatusRes, isLoading } = useVoteStatus(memory.id);
+  const toggleVote = useToggleVote();
+
+  // Inline nudge shown when the user is authenticated but has no User row (403)
+  const [showOnboardPrompt, setShowOnboardPrompt] = useState(false);
+
+  // While loading use the count baked into the memory object so the number
+  // never flashes 0 on first render.
+  const voteCount = isLoading
+    ? (memory._count?.votes ?? 0)
+    : (voteStatusRes?.data?.voteCount ?? memory._count?.votes ?? 0);
+
+  const hasVoted = voteStatusRes?.data?.hasVoted ?? false;
+
+  const handleLike = () => {
+    if (!isAuthenticated) return; // unauthenticated — silently no-op
+
+    toggleVote.mutate(
+      { memoryId: memory.id },
+      {
+        onError: (err) => {
+          const status = (err as Error & { status?: number }).status;
+          if (status === 403) {
+            setShowOnboardPrompt(true);
+            setTimeout(() => setShowOnboardPrompt(false), 3000);
+          }
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {/* ── Vote count strip ─────────────────────────────────────────── */}
+      <div className="flex items-center gap-1.5 px-1">
+        <Heart
+          className={`h-4 w-4 shrink-0 transition-colors ${
+            hasVoted ? 'fill-red-500 text-red-500' : 'text-slate-400'
+          }`}
+        />
+        <span className="text-sm font-medium text-slate-500">
+          {formatVoteCount(voteCount)}
+        </span>
+
+        {showOnboardPrompt && (
+          <span className="ml-1 text-xs text-amber-500">
+            Complete onboarding to vote
+          </span>
+        )}
+      </div>
+
+      {/* ── Action icons ─────────────────────────────────────────────── */}
+      <div className="flex items-center justify-center gap-4">
+        <button
+          className="text-slate-600 hover:text-slate-800"
+          aria-label="Copy"
+        >
+          <Copy className="h-5 w-5" />
+        </button>
+
+        <button
+          onClick={handleLike}
+          disabled={!isAuthenticated || toggleVote.isPending}
+          className={`transition-colors ${
+            !isAuthenticated
+              ? 'cursor-default text-slate-300'
+              : hasVoted
+                ? 'text-red-500 hover:text-red-400'
+                : 'text-slate-600 hover:text-slate-800'
+          }`}
+          aria-label={hasVoted ? 'Unlike' : 'Like'}
+          aria-pressed={hasVoted}
+        >
+          <Heart
+            className={`h-5 w-5 transition-all ${hasVoted ? 'fill-current' : ''}`}
+          />
+        </button>
+
+        <button
+          className="text-slate-600 hover:text-slate-800"
+          aria-label="Share"
+        >
+          <Share className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/MemoryDetailModal.tsx
+++ b/src/components/map/MemoryDetailModal.tsx
@@ -1,18 +1,11 @@
 'use client';
 
-import {
-  Copy,
-  Heart,
-  Share,
-  MoreHorizontal,
-  Globe,
-  ChevronLeft,
-  ChevronRight,
-} from 'lucide-react';
+import { MoreHorizontal, Globe, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Dialog, DialogTitle } from '@/components/ui/dialog';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import type { MemoryWithCoordinates } from '@/lib/hooks/useAllMemoriesWithCoordinates';
+import { ActionBar } from '@/components/map/ActionBar';
 import Image from 'next/image';
 import { useState, useEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -487,27 +480,8 @@ export function MemoryDetailModal({
                             </p>
                           </div>
 
-                          {/* Action icons */}
-                          <div className="flex items-center justify-center gap-4">
-                            <button
-                              className="text-slate-600 hover:text-slate-800"
-                              aria-label="Copy"
-                            >
-                              <Copy className="h-5 w-5" />
-                            </button>
-                            <button
-                              className="text-slate-600 hover:text-slate-800"
-                              aria-label="Like"
-                            >
-                              <Heart className="h-5 w-5" />
-                            </button>
-                            <button
-                              className="text-slate-600 hover:text-slate-800"
-                              aria-label="Share"
-                            >
-                              <Share className="h-5 w-5" />
-                            </button>
-                          </div>
+                          {/* Action bar */}
+                          <ActionBar memory={baseRightMemory} />
 
                           {/* Comments section */}
                           <div className="flex-1">
@@ -702,27 +676,8 @@ export function MemoryDetailModal({
                                   </p>
                                 </div>
 
-                                {/* Action icons */}
-                                <div className="flex items-center justify-center gap-4">
-                                  <button
-                                    className="text-slate-600 hover:text-slate-800"
-                                    aria-label="Copy"
-                                  >
-                                    <Copy className="h-5 w-5" />
-                                  </button>
-                                  <button
-                                    className="text-slate-600 hover:text-slate-800"
-                                    aria-label="Like"
-                                  >
-                                    <Heart className="h-5 w-5" />
-                                  </button>
-                                  <button
-                                    className="text-slate-600 hover:text-slate-800"
-                                    aria-label="Share"
-                                  >
-                                    <Share className="h-5 w-5" />
-                                  </button>
-                                </div>
+                                {/* Action bar */}
+                                <ActionBar memory={memory} />
 
                                 {/* Comments section */}
                                 <div className="flex-1">
@@ -823,27 +778,8 @@ export function MemoryDetailModal({
                                 </p>
                               </div>
 
-                              {/* Action icons */}
-                              <div className="flex items-center justify-center gap-4">
-                                <button
-                                  className="text-slate-600 hover:text-slate-800"
-                                  aria-label="Copy"
-                                >
-                                  <Copy className="h-5 w-5" />
-                                </button>
-                                <button
-                                  className="text-slate-600 hover:text-slate-800"
-                                  aria-label="Like"
-                                >
-                                  <Heart className="h-5 w-5" />
-                                </button>
-                                <button
-                                  className="text-slate-600 hover:text-slate-800"
-                                  aria-label="Share"
-                                >
-                                  <Share className="h-5 w-5" />
-                                </button>
-                              </div>
+                              {/* Action bar */}
+                              <ActionBar memory={cachedMemory!} />
 
                               {/* Comments section */}
                               <div className="flex-1">

--- a/src/lib/hooks/useToggleVote.ts
+++ b/src/lib/hooks/useToggleVote.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useRef } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface VoteStatusData {
+  success: boolean;
+  data: { hasVoted: boolean; voteCount: number };
+}
+
+interface ToggleVotePayload {
+  memoryId: string;
+}
+
+interface ToggleVoteResponse {
+  success: boolean;
+  message: string;
+  data: { voted: boolean; voteCount: number };
+}
+
+const DEBOUNCE_MS = 2_000;
+
+export function useToggleVote() {
+  const queryClient = useQueryClient();
+
+  // Per-memoryId last-toggle timestamp — mirrors the server-side rate limit so
+  // we avoid sending a request we know will return 429.
+  const lastToggleRef = useRef<Map<string, number>>(new Map());
+
+  const mutation = useMutation({
+    mutationFn: async ({ memoryId }: ToggleVotePayload) => {
+      const now = Date.now();
+      const last = lastToggleRef.current.get(memoryId);
+
+      // Client-side debounce guard — silently swallow the click.
+      if (last !== undefined && now - last < DEBOUNCE_MS) return null;
+
+      lastToggleRef.current.set(memoryId, now);
+
+      const res = await fetch('/api/prisma/memory/vote/toggle', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ memoryId }),
+      });
+
+      const json = (await res.json()) as ToggleVoteResponse & {
+        success: false;
+        message: string;
+      };
+
+      if (!res.ok) {
+        throw Object.assign(new Error(json.message ?? 'Vote failed'), {
+          status: res.status,
+        });
+      }
+
+      return json;
+    },
+
+    // ── Optimistic update ──────────────────────────────────────────────────
+    onMutate: async ({ memoryId }) => {
+      await queryClient.cancelQueries({ queryKey: ['vote-status', memoryId] });
+
+      const snapshot = queryClient.getQueryData<VoteStatusData>([
+        'vote-status',
+        memoryId,
+      ]);
+
+      if (snapshot) {
+        const current = snapshot.data;
+        queryClient.setQueryData<VoteStatusData>(['vote-status', memoryId], {
+          ...snapshot,
+          data: {
+            hasVoted: !current.hasVoted,
+            voteCount: current.hasVoted
+              ? current.voteCount - 1
+              : current.voteCount + 1,
+          },
+        });
+      }
+
+      return { snapshot, memoryId };
+    },
+
+    // ── Roll back on error ─────────────────────────────────────────────────
+    onError: (_err, _variables, context) => {
+      if (context?.snapshot) {
+        queryClient.setQueryData(
+          ['vote-status', context.memoryId],
+          context.snapshot
+        );
+      }
+    },
+
+    // ── Reconcile with server on settle ───────────────────────────────────
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['vote-status', variables.memoryId],
+      });
+    },
+  });
+
+  return mutation;
+}

--- a/src/lib/hooks/useVoteStatus.ts
+++ b/src/lib/hooks/useVoteStatus.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+interface VoteStatusResponse {
+  success: boolean;
+  data: {
+    hasVoted: boolean;
+    voteCount: number;
+  };
+}
+
+export function useVoteStatus(memoryId: string | undefined) {
+  return useQuery({
+    queryKey: ['vote-status', memoryId],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/prisma/memory/vote/status?memoryId=${memoryId}`
+      );
+      if (!res.ok) throw new Error('Failed to fetch vote status');
+      return res.json() as Promise<VoteStatusResponse>;
+    },
+    enabled: !!memoryId,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -90,6 +90,23 @@ export const memoriesByLocationQuerySchema = z.object({
 });
 
 // ============================================================================
+// VOTE SCHEMAS
+// ============================================================================
+
+/** Payload for toggling a vote — userId comes from server-side auth, never the client. */
+export const toggleVoteSchema = z.object({
+  memoryId: z.string().uuid('Invalid memory ID'),
+});
+
+/** Query params for fetching vote status on a single memory. */
+export const voteStatusQuerySchema = z.object({
+  memoryId: z.string().uuid('Invalid memory ID'),
+});
+
+export type ToggleVoteInput = z.infer<typeof toggleVoteSchema>;
+export type VoteStatusQuery = z.infer<typeof voteStatusQuerySchema>;
+
+// ============================================================================
 // MEMORY TYPE EXPORTS
 // ============================================================================
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -25,6 +25,18 @@ export function getEraFromBatchTag(
   return 2020;
 }
 
+/**
+ * Formats a vote count for compact display:
+ *   < 1 000        → exact number  (e.g. "42")
+ *   1 000–999 999  → one decimal k  (e.g. "1.2k")
+ *   ≥ 1 000 000    → one decimal m  (e.g. "3.5m")
+ */
+export function formatVoteCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}m`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return String(count);
+}
+
 // This check can be removed, it is just for tutorial purposes
 export const hasEnvVars =
   process.env.NEXT_PUBLIC_SUPABASE_URL &&

--- a/src/services/toggle-vote-service.ts
+++ b/src/services/toggle-vote-service.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Toggles a vote on a memory for the given user inside a single transaction:
+ *   - If the vote record exists → delete it (un-vote)
+ *   - If it doesn't exist     → create it (vote)
+ *
+ * Returns the definitive state after the toggle plus the new total vote count.
+ */
+export async function toggleVoteService(
+  memoryId: string,
+  userId: string
+): Promise<{ voted: boolean; voteCount: number }> {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.memoryVote.findUnique({
+      where: { memoryId_userId: { memoryId, userId } },
+      select: { id: true },
+    });
+
+    if (existing) {
+      await tx.memoryVote.delete({
+        where: { memoryId_userId: { memoryId, userId } },
+      });
+    } else {
+      await tx.memoryVote.create({
+        data: { memoryId, userId },
+      });
+    }
+
+    const voteCount = await tx.memoryVote.count({ where: { memoryId } });
+
+    return { voted: !existing, voteCount };
+  });
+}


### PR DESCRIPTION
## Summary

Implements memory upvote engagement — a Heart button in the memory detail modal that toggles votes, shows a live count, and handles auth edge cases gracefully. Includes the full API, service, hook, and UI layers.

**Vote infrastructure:**

- **Zod schemas** in `schemas.ts` — `toggleVoteSchema` (`memoryId` UUID; `userId` never client-supplied) and `voteStatusQuerySchema` (`memoryId` UUID for the GET endpoint). Exported `ToggleVoteInput` and `VoteStatusQuery` types. `MemoryWithRelations` left unchanged — `hasVoted`/`voteCount` live in a separate query response to keep existing memory-fetch routes untouched.
- **`toggleVoteService`** in toggle-vote-service.ts — encapsulates the entire toggle in a single Prisma `$transaction`: `findUnique` on the `@@unique([memoryId, userId])` composite → `delete`/`create` → `count({ where: { memoryId } })` → returns `{ voted, voteCount }`. Pure data logic, no HTTP or auth concerns. Follows the `create-memory-service` pattern.

**API routes:**

- **`POST /api/prisma/memory/vote/toggle`** — full auth flow: Supabase `getUser()` → Prisma `User` row check (403 with "Complete onboarding before voting" if missing) → dev seed-user fallback when `NODE_ENV === 'development'` → 401 in production without a session. Body validated with `toggleVoteSchema.safeParse`. In-process rate limiter (module-scoped `Map<string, number>` keyed `userId:memoryId`, 2 s cooldown, 429 on hit) with a Redis/Upstash upgrade-path comment. Calls `toggleVoteService` and returns `{ success, message, data: { voted, voteCount } }`.
- **`GET /api/prisma/memory/vote/status`** — `voteCount` is always returned (public data). `hasVoted` defaults to `false` for unauthenticated callers or those with no `User` row. Same dev seed-user fallback as toggle. Response: `{ success, data: { hasVoted, voteCount } }`.

**Client hooks:**

- **`useVoteStatus`** — `useQuery` with key `['vote-status', memoryId]`, `staleTime: 5 min`, `enabled: !!memoryId`. Fires once on modal open.
- **`useToggleVote`** — `useMutation` with client-side debounce guard (`useRef<Map<string, number>>`, 2 s per `memoryId`, silently swallows rapid clicks). Optimistic update in `onMutate` (flip `hasVoted`, ±1 `voteCount`), snapshot rollback in `onError`, cache invalidation in `onSettled`. 403 response surfaced via mutation error `.status` for the component to handle.
- **`formatVoteCount`** added to `utils.ts` — pure formatter: exact below 1 000, `#.#k` for thousands, `#.#m` for millions.

**`ActionBar` component:**

- New `'use client'` component at ActionBar.tsx. Wires `useVoteStatus`, `useToggleVote`, and `useUserAuth`.
- Two-row layout: vote count strip (small Heart + formatted count, left-aligned) above the Copy | Heart | Share action row.
- Loading fallback: `memory._count?.votes ?? 0` so the count never flashes 0 on first render.
- Heart fills red + `text-red-500` when `hasVoted`; outlined + `text-slate-300` + `cursor-default` when unauthenticated (click is a silent no-op).
- 403 response → 3-second inline amber nudge "Complete onboarding to vote" via local `useState`.

**MemoryDetailModal integration:**

- All three duplicated inline action-icon `<div>`s replaced with `<ActionBar memory={...} />` (`baseRightMemory`, `memory`, `cachedMemory`). `Copy`, `Heart`, `Share` removed from the `lucide-react` import.

---

### What's intentionally deferred

- Gallery view voting (MemoryDetailModal only for now)
- Persistent rate limiting across serverless instances (in-process map; Redis upgrade path documented in a code comment)
- "Sign in to vote" tooltip for unauthenticated users (silent no-op path chosen; tooltip is an explicit `or` branch in the spec)
- JIT `User` row provisioning — broken onboarding returns 403 with a prompt; fix is a separate workstream

### Relation to prior work

Builds on the memory creation and tag management infrastructure from previous PRs. Reuses the same patterns: Zod `safeParse` validation, `{ success, message, data }` response envelope, `useQuery`/`useMutation` hooks with typed responses, Supabase auth helpers, and the service-layer separation established in `create-memory-service.ts`. Uses the existing `MemoryWithRelations` type and `useUserAuth` hook without modification.