### PR TITLE
Scrum 38 build search and filter UI (Profile Page Pivot)

### DIFF
--- a/src/app/protected/layout.tsx
+++ b/src/app/protected/layout.tsx
@@ -1,15 +1,20 @@
+import { Header } from '@/components/header';
+
 export default function ProtectedLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <main className="flex min-h-screen flex-col items-center">
-      <div className="flex w-full flex-1 flex-col items-center gap-20">
-        <div className="flex max-w-5xl flex-1 flex-col gap-20 p-5">
-          {children}
+    <>
+      <Header />
+      <main className="flex min-h-screen flex-col items-center pt-20">
+        <div className="flex w-full flex-1 flex-col items-center gap-20">
+          <div className="flex max-w-5xl flex-1 flex-col gap-20 p-5">
+            {children}
+          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/src/app/protected/profile/page.tsx
+++ b/src/app/protected/profile/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useUserAuth } from '@/hooks/useUserAuth';
+import { ProfileHero } from '@/components/profile/ProfileHero';
+import { ProfileBioCard } from '@/components/profile/ProfileBioCard';
+import { ProfileContactCard } from '@/components/profile/ProfileContactCard';
+import { ProfileAcademicCard } from '@/components/profile/ProfileAcademicCard';
+import { ProfileActivityCard } from '@/components/profile/ProfileActivityCard';
+import { ProfileSettingsCard } from '@/components/profile/ProfileSettingsCard';
+
+export default function ProfilePage() {
+  const { user, loading } = useUserAuth();
+
+  if (loading) {
+    return (
+      <div className="flex w-full flex-1 flex-col gap-6">
+        <div className="h-32 animate-pulse rounded-xl bg-muted" />
+        <div className="grid gap-6 md:grid-cols-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-40 animate-pulse rounded-xl bg-muted" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-1 flex-col gap-6">
+      <ProfileHero user={user} />
+      <div className="grid gap-6 md:grid-cols-2">
+        <ProfileBioCard />
+        <ProfileContactCard />
+        <ProfileAcademicCard />
+        <ProfileActivityCard />
+        <ProfileSettingsCard />
+      </div>
+    </div>
+  );
+}

--- a/src/components/account-menu.tsx
+++ b/src/components/account-menu.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useRouter } from 'next/navigation';
@@ -49,10 +50,12 @@ export function AccountMenu() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {userName && (
-          <div className="px-2 py-1.5 text-sm font-medium text-gray-700">
-            {userName}
-          </div>
+          <DropdownMenuItem onClick={() => router.push('/protected/profile')}>
+            <User className="mr-2 h-4 w-4" />
+            <span>{userName}</span>
+          </DropdownMenuItem>
         )}
+        <DropdownMenuSeparator />
         <DropdownMenuItem onClick={handleLogout}>
           <LogOut className="mr-2 h-4 w-4" />
           <span>Log Out</span>

--- a/src/components/profile/ProfileAcademicCard.tsx
+++ b/src/components/profile/ProfileAcademicCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+const academicRows = [
+  { label: 'Student ID', value: '—' },
+  { label: 'Program', value: '—' },
+  { label: 'Batch', value: '—' },
+  { label: 'Status', value: 'Student' },
+];
+
+export function ProfileAcademicCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Academic Details</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {academicRows.map(({ label, value }) => (
+            <li key={label} className="flex items-center justify-between gap-4">
+              <span className="text-sm font-medium text-foreground/70">
+                {label}
+              </span>
+              <span className="text-sm text-muted-foreground">{value}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/ProfileActivityCard.tsx
+++ b/src/components/profile/ProfileActivityCard.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+const mockActivity = [
+  {
+    date: 'Feb 28, 2026',
+    title: 'Sunset Watch with Blockmates',
+    location: 'Amphitheater',
+  },
+  { date: 'Feb 14, 2026', title: 'Cultural Night', location: 'Sunset Garden' },
+  { date: 'Jan 30, 2026', title: 'Block Photo at the Oval', location: 'Oval' },
+];
+
+export function ProfileActivityCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Recent Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-4">
+          {mockActivity.map(({ date, title, location }) => (
+            <li key={title} className="flex flex-col gap-0.5">
+              <span className="text-xs text-muted-foreground">
+                {date} · {location}
+              </span>
+              <span className="text-sm font-medium text-foreground/80">
+                {title}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-4 text-xs italic text-muted-foreground">
+          Activity feed coming soon.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/ProfileBioCard.tsx
+++ b/src/components/profile/ProfileBioCard.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+export function ProfileBioCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">About Me</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md border border-dashed bg-muted/40 px-4 py-6 text-center">
+          <p className="text-sm italic text-muted-foreground">
+            No bio added yet.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/ProfileContactCard.tsx
+++ b/src/components/profile/ProfileContactCard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+interface ContactRow {
+  label: string;
+  value?: string;
+}
+
+const contactRows: ContactRow[] = [
+  { label: 'Phone' },
+  { label: 'LinkedIn' },
+  { label: 'Facebook' },
+  { label: 'Other' },
+];
+
+export function ProfileContactCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Contact Information</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {contactRows.map(({ label, value }) => (
+            <li key={label} className="flex items-center justify-between gap-4">
+              <span className="text-sm font-medium text-foreground/70">
+                {label}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {value ?? 'Not provided'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/ProfileHero.tsx
+++ b/src/components/profile/ProfileHero.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { User } from '@supabase/supabase-js';
+import Image from 'next/image';
+import { User as UserIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ProfileHeroProps {
+  user: User | null;
+}
+
+export function ProfileHero({ user }: ProfileHeroProps) {
+  const avatarUrl =
+    user?.user_metadata?.avatar_url || user?.user_metadata?.picture;
+  const displayName =
+    user?.user_metadata?.full_name ||
+    user?.user_metadata?.name ||
+    user?.email ||
+    'Unknown User';
+  const email = user?.email;
+
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-xl border bg-card p-8 text-center shadow sm:flex-row sm:text-left">
+      <div className="shrink-0">
+        {avatarUrl ? (
+          <Image
+            src={avatarUrl}
+            alt={displayName}
+            width={96}
+            height={96}
+            className="h-24 w-24 rounded-full object-cover"
+          />
+        ) : (
+          <div className="flex h-24 w-24 items-center justify-center rounded-full bg-skolaroid-blue text-white">
+            <UserIcon className="h-10 w-10" />
+          </div>
+        )}
+      </div>
+      <div className="flex flex-1 flex-col gap-1 sm:gap-2">
+        <h1 className="text-2xl font-bold text-foreground">{displayName}</h1>
+        {email && <p className="text-sm text-muted-foreground">{email}</p>}
+        <p className="text-xs text-muted-foreground">Student · Batch 2024</p>
+      </div>
+      <div className="shrink-0">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled
+          className="cursor-not-allowed opacity-50"
+        >
+          Edit Profile
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileSettingsCard.tsx
+++ b/src/components/profile/ProfileSettingsCard.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export function ProfileSettingsCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Account Settings</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled
+            className="w-fit cursor-not-allowed opacity-50"
+          >
+            Change Password
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Password change is not available yet.
+          </p>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled
+            className="w-fit cursor-not-allowed border-destructive/50 text-destructive opacity-50 hover:bg-transparent"
+          >
+            Delete Account
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Account deletion is not available yet.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Scaffolds a user profile page at `/protected/profile` with placeholder section cards and wires up navigation to it from the account dropdown.

- **Protected layout** updated to render `<Header />` and add `pt-20` top padding so all current and future `/protected/*` routes get consistent navigation without duplicating the header in each page.
- **Profile section components** added under profile — `ProfileHero` (avatar, name, email, disabled Edit button), `ProfileBioCard`, `ProfileContactCard`, `ProfileAcademicCard`, `ProfileActivityCard`, and `ProfileSettingsCard`. All use existing `Card` and `Avatar` UI primitives and carry placeholder/mocked content.
- **Profile page** at page.tsx — `'use client'` component that reads auth state via `useUserAuth()`, shows an animated skeleton while loading, then renders the hero with a two-column responsive grid of the five section cards below.
- **AccountMenu** updated so the username entry is now a `DropdownMenuItem` with a `User` icon that navigates to `/protected/profile` via `router.push`. A `DropdownMenuSeparator` separates it from Log Out.

### What's intentionally deferred

- Fetching the Prisma `User` record — section cards use static placeholder values; no `GET /user/me` route exists yet
- Prisma schema additions (`bio`, `avatarUrl`, `contactInfo`) — requires a migration and is a separate concern
- Edit Profile functionality — button is present but disabled
- Avatar upload — Supabase storage integration deferred
- Activity feed — `ProfileActivityCard` uses 3 mocked entries