### PR TITLE
Scrum 19 group owner can view and manage members

### DIFF
--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -11,11 +11,8 @@ import { DeleteGroupModal } from '@/components/groups/DeleteGroupModal';
 import { MembersTab } from '@/components/groups/tabs/MembersTab';
 import { MediaTab } from '@/components/groups/tabs/MediaTab';
 import { AboutTab } from '@/components/groups/tabs/AboutTab';
-import {
-  type Group,
-  MOCK_GROUPS,
-  MOCK_CURRENT_USER_ID,
-} from '@/lib/types/group';
+import { type Group, MOCK_GROUPS } from '@/lib/types/group';
+import { useUserAuth } from '@/hooks/useUserAuth';
 import { type GroupResponse } from '@/lib/hooks/useCreateGroup';
 import { cn } from '@/lib/utils';
 import {
@@ -61,6 +58,8 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const [activeTab, setActiveTab] = useState<TabType>('members');
 
   const { showSuccess } = useGroupToast();
+  const { user } = useUserAuth();
+  const currentUserId = user?.id ?? '';
 
   const handleGroupCreated = useCallback(
     (groupResponse: GroupResponse) => {
@@ -80,7 +79,10 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
           name:
             `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim() ||
             member.email,
-          role: 'MEMBER' as const, // Set based on creator check if needed
+          role:
+            member.id === groupResponse.creatorId
+              ? ('OWNER' as const)
+              : ('MEMBER' as const),
           joinedAt: new Date().toISOString(),
         })),
         createdAt: groupResponse.createdAt,
@@ -109,9 +111,9 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
     [groups]
   );
 
-  const isOwner = selectedGroup?.ownerId === MOCK_CURRENT_USER_ID;
+  const isOwner = selectedGroup?.ownerId === currentUserId;
   const currentUserMember = selectedGroup?.members.find(
-    (m) => m.id === MOCK_CURRENT_USER_ID
+    (m) => m.id === currentUserId
   );
   const isAdmin = currentUserMember?.role === 'ADMIN';
 
@@ -294,6 +296,7 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
                     <MembersTab
                       members={selectedGroup.members}
                       isOwner={isOwner}
+                      currentUserId={currentUserId}
                     />
                   )}
                   {activeTab === 'media' && <MediaTab />}

--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { GroupSwitcher, useGroupToast } from '@/components/groups';
 import { CreateGroupModal } from '@/components/groups/CreateGroupModal';
@@ -11,9 +11,16 @@ import { DeleteGroupModal } from '@/components/groups/DeleteGroupModal';
 import { MembersTab } from '@/components/groups/tabs/MembersTab';
 import { MediaTab } from '@/components/groups/tabs/MediaTab';
 import { AboutTab } from '@/components/groups/tabs/AboutTab';
-import { type Group, MOCK_GROUPS } from '@/lib/types/group';
+import { type Group, type GroupMember } from '@/lib/types/group';
 import { useUserAuth } from '@/hooks/useUserAuth';
-import { type GroupResponse } from '@/lib/hooks/useCreateGroup';
+import {
+  type GroupResponse,
+  type GroupMemberResponse,
+} from '@/lib/hooks/useCreateGroup';
+import { useUserGroups } from '@/lib/hooks/useUserGroups';
+import { useGroupById } from '@/lib/hooks/useGroupById';
+import { useDeleteGroup } from '@/lib/hooks/useDeleteGroup';
+import { useRemoveGroupMember } from '@/lib/hooks/useGroupMembers';
 import { cn } from '@/lib/utils';
 import {
   X,
@@ -27,6 +34,7 @@ import {
   LogOut,
   Globe,
   Lock,
+  Loader2,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -45,11 +53,39 @@ interface GroupPanelProps {
 
 type TabType = 'members' | 'media' | 'about';
 
+/** Transform an API member response to the frontend GroupMember shape. */
+function toGroupMember(
+  m: GroupMemberResponse,
+  creatorId: string | null
+): GroupMember {
+  return {
+    id: m.id,
+    name: `${m.firstName ?? ''} ${m.lastName ?? ''}`.trim() || m.email,
+    email: m.email,
+    role: m.id === creatorId ? ('OWNER' as const) : ('MEMBER' as const),
+    joinedAt: new Date().toISOString(),
+  };
+}
+
+/** Transform an API GroupResponse to the frontend Group shape. */
+function toGroup(g: GroupResponse): Group {
+  return {
+    id: g.id,
+    name: g.name,
+    description: g.description ?? undefined,
+    privacy: 'PRIVATE',
+    visibility: 'VISIBLE',
+    coverPhotoUrl: undefined,
+    memberCount: g._count.members,
+    postCount: g._count.memories,
+    ownerId: g.creatorId ?? '',
+    members: g.members.map((m) => toGroupMember(m, g.creatorId)),
+    createdAt: g.createdAt,
+  };
+}
+
 export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
-  const [groups, setGroups] = useState<Group[]>(MOCK_GROUPS);
-  const [selectedGroup, setSelectedGroup] = useState<Group | null>(
-    MOCK_GROUPS[0] ?? null
-  );
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [inviteModalOpen, setInviteModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
@@ -57,65 +93,106 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType>('members');
 
-  const { showSuccess } = useGroupToast();
+  const { showSuccess, showError } = useGroupToast();
   const { user } = useUserAuth();
   const currentUserId = user?.id ?? '';
 
-  const handleGroupCreated = useCallback(
-    (groupResponse: GroupResponse) => {
-      // Transform API GroupResponse to frontend Group type
-      const newGroup: Group = {
-        id: groupResponse.id,
-        name: groupResponse.name,
-        description: groupResponse.description ?? undefined,
-        privacy: 'PUBLIC', // Default to PUBLIC - adjust based on form if available
-        visibility: 'VISIBLE', // Default to VISIBLE - adjust based on form if available
-        coverPhotoUrl: undefined,
-        memberCount: groupResponse._count.members,
-        postCount: 0, // API doesn't return media count yet
-        ownerId: groupResponse.creatorId ?? '',
-        members: groupResponse.members.map((member) => ({
-          id: member.id,
-          name:
-            `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim() ||
-            member.email,
-          role:
-            member.id === groupResponse.creatorId
-              ? ('OWNER' as const)
-              : ('MEMBER' as const),
-          joinedAt: new Date().toISOString(),
-        })),
-        createdAt: groupResponse.createdAt,
-      };
-      setGroups((prev) => [newGroup, ...prev]);
-      setSelectedGroup(newGroup);
-      showSuccess(`Group "${newGroup.name}" created successfully!`);
-    },
-    [showSuccess]
+  // ─── Data fetching ───────────────────────────────────────────────
+  const { data: groupsRaw, isLoading: isLoadingGroups } = useUserGroups();
+
+  const { data: groupDetailRaw, refetch: refetchGroupDetail } = useGroupById(
+    selectedGroupId ?? ''
   );
 
-  const handleGroupDeleted = useCallback(
-    (groupId: string) => {
-      setGroups((prev) => prev.filter((g) => g.id !== groupId));
-      setSelectedGroup(groups.find((g) => g.id !== groupId) ?? null);
-      onOpenChange(false);
-    },
-    [groups, onOpenChange]
-  );
+  const deleteGroup = useDeleteGroup();
+  const leaveGroup = useRemoveGroupMember();
 
-  const handleGroupLeft = useCallback(
-    (groupId: string) => {
-      setGroups((prev) => prev.filter((g) => g.id !== groupId));
-      setSelectedGroup(groups.find((g) => g.id !== groupId) ?? null);
-    },
-    [groups]
-  );
+  // ─── Derived state ───────────────────────────────────────────────
+  const groups: Group[] = useMemo(() => {
+    if (!groupsRaw) return [];
+    return groupsRaw.map(toGroup);
+  }, [groupsRaw]);
+
+  // Auto-select first group when list loads
+  useEffect(() => {
+    if (groups.length > 0 && !selectedGroupId) {
+      setSelectedGroupId(groups[0].id);
+    }
+  }, [groups, selectedGroupId]);
+
+  // Build the selected group from either the detail query or the list
+  const selectedGroup: Group | null = useMemo(() => {
+    if (groupDetailRaw)
+      return toGroup(groupDetailRaw as unknown as GroupResponse);
+    return groups.find((g) => g.id === selectedGroupId) ?? null;
+  }, [groupDetailRaw, groups, selectedGroupId]);
 
   const isOwner = selectedGroup?.ownerId === currentUserId;
   const currentUserMember = selectedGroup?.members.find(
     (m) => m.id === currentUserId
   );
   const isAdmin = currentUserMember?.role === 'ADMIN';
+
+  // ─── Handlers ────────────────────────────────────────────────────
+  const handleSelectGroup = useCallback((group: Group) => {
+    setSelectedGroupId(group.id);
+  }, []);
+
+  const handleGroupCreated = useCallback(
+    (groupResponse: GroupResponse) => {
+      setSelectedGroupId(groupResponse.id);
+      showSuccess(`Group "${groupResponse.name}" created successfully!`);
+    },
+    [showSuccess]
+  );
+
+  const handleGroupDeleted = useCallback(() => {
+    if (!selectedGroup) return;
+
+    deleteGroup.mutate(selectedGroup.id, {
+      onSuccess: () => {
+        showSuccess(`Group "${selectedGroup.name}" deleted.`);
+        setSelectedGroupId(
+          groups.find((g) => g.id !== selectedGroup.id)?.id ?? null
+        );
+        onOpenChange(false);
+      },
+      onError: (err) => {
+        showError(err.message);
+      },
+    });
+  }, [
+    selectedGroup,
+    groups,
+    deleteGroup,
+    onOpenChange,
+    showSuccess,
+    showError,
+  ]);
+
+  const handleGroupLeft = useCallback(() => {
+    if (!selectedGroup || !user?.email) return;
+
+    leaveGroup.mutate(
+      { groupId: selectedGroup.id, email: user.email },
+      {
+        onSuccess: () => {
+          showSuccess(`You left "${selectedGroup.name}".`);
+          setSelectedGroupId(
+            groups.find((g) => g.id !== selectedGroup.id)?.id ?? null
+          );
+        },
+        onError: (err) => {
+          showError(err.message);
+        },
+      }
+    );
+  }, [selectedGroup, user?.email, groups, leaveGroup, showSuccess, showError]);
+
+  const handleMemberRemoved = useCallback(() => {
+    refetchGroupDetail();
+    showSuccess('Member removed successfully.');
+  }, [refetchGroupDetail, showSuccess]);
 
   return (
     <>
@@ -140,7 +217,7 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
               <GroupSwitcher
                 groups={groups}
                 selectedGroup={selectedGroup}
-                onSelectGroup={setSelectedGroup}
+                onSelectGroup={handleSelectGroup}
                 onCreateGroup={() => setCreateModalOpen(true)}
               />
             </div>
@@ -297,6 +374,8 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
                       members={selectedGroup.members}
                       isOwner={isOwner}
                       currentUserId={currentUserId}
+                      groupId={selectedGroup.id}
+                      onMemberRemoved={handleMemberRemoved}
                     />
                   )}
                   {activeTab === 'media' && <MediaTab />}
@@ -305,13 +384,19 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
               </>
             ) : (
               <div className="flex h-full flex-col items-center justify-center px-5 py-8">
-                <Users className="mb-3 h-12 w-12 text-gray-300" />
-                <h3 className="text-base font-semibold text-gray-900">
-                  No Group Selected
-                </h3>
-                <p className="mt-1 text-center text-sm text-gray-600">
-                  Select a group from the sidebar or create a new one
-                </p>
+                {isLoadingGroups ? (
+                  <Loader2 className="h-8 w-8 animate-spin text-gray-300" />
+                ) : (
+                  <>
+                    <Users className="mb-3 h-12 w-12 text-gray-300" />
+                    <h3 className="text-base font-semibold text-gray-900">
+                      No Group Selected
+                    </h3>
+                    <p className="mt-1 text-center text-sm text-gray-600">
+                      Select a group from the sidebar or create a new one
+                    </p>
+                  </>
+                )}
               </div>
             )}
           </div>
@@ -347,14 +432,14 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
             open={leaveModalOpen}
             onOpenChange={setLeaveModalOpen}
             groupName={selectedGroup.name}
-            onConfirmLeave={() => handleGroupLeft(selectedGroup.id)}
+            onConfirmLeave={handleGroupLeft}
           />
 
           <DeleteGroupModal
             open={deleteModalOpen}
             onOpenChange={setDeleteModalOpen}
             groupName={selectedGroup.name}
-            onConfirmDelete={() => handleGroupDeleted(selectedGroup.id)}
+            onConfirmDelete={handleGroupDeleted}
           />
         </>
       )}

--- a/src/components/groups/RemoveMemberDialog.tsx
+++ b/src/components/groups/RemoveMemberDialog.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { UserMinus } from 'lucide-react';
+
+interface RemoveMemberDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  memberName: string;
+  isLoading?: boolean;
+  onConfirm: () => void;
+}
+
+export function RemoveMemberDialog({
+  open,
+  onOpenChange,
+  memberName,
+  isLoading,
+  onConfirm,
+}: RemoveMemberDialogProps) {
+  const handleClose = () => {
+    if (!isLoading) onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(val) => !val && handleClose()}>
+      <DialogContent
+        className="max-w-xs gap-0 overflow-hidden rounded-2xl border-gray-100 p-0 shadow-2xl"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">Remove Member</DialogTitle>
+
+        <div className="flex flex-col items-center px-6 pb-6 pt-7 text-center">
+          <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-red-50">
+            <UserMinus size={18} className="text-red-500" />
+          </div>
+          <h2 className="text-base font-semibold text-gray-900">
+            Remove Member?
+          </h2>
+          <p className="mt-1.5 text-xs leading-relaxed text-gray-400">
+            Are you sure you want to remove{' '}
+            <span className="font-medium text-gray-600">{memberName}</span> from
+            this group? They will need a new invite to rejoin.
+          </p>
+
+          <div className="mt-5 flex w-full gap-2">
+            <button
+              onClick={handleClose}
+              disabled={isLoading}
+              className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={onConfirm}
+              disabled={isLoading}
+              className="flex-1 rounded-xl bg-red-500 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-red-600 active:scale-[0.98] disabled:opacity-50"
+            >
+              {isLoading ? 'Removing…' : 'Remove'}
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/index.ts
+++ b/src/components/groups/index.ts
@@ -6,4 +6,5 @@ export * from './DeleteGroupModal';
 export * from './InviteMembersModal';
 export * from './ShareGroupModal';
 export * from './LeaveGroupModal';
+export * from './RemoveMemberDialog';
 export * from './GroupToast';

--- a/src/components/groups/tabs/MembersTab.tsx
+++ b/src/components/groups/tabs/MembersTab.tsx
@@ -12,11 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import {
-  type GroupMember,
-  type GroupMemberRole,
-  MOCK_CURRENT_USER_ID,
-} from '@/lib/types/group';
+import { type GroupMember, type GroupMemberRole } from '@/lib/types/group';
 import { cn } from '@/lib/utils';
 import {
   MoreHorizontal,
@@ -30,11 +26,16 @@ import {
 interface MembersTabProps {
   members: GroupMember[];
   isOwner: boolean;
+  currentUserId: string;
 }
 
 type RoleFilterType = 'ALL' | GroupMemberRole;
 
-export function MembersTab({ members, isOwner }: MembersTabProps) {
+export function MembersTab({
+  members,
+  isOwner,
+  currentUserId,
+}: MembersTabProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [roleFilter, setRoleFilter] = useState<RoleFilterType>('ALL');
 
@@ -162,7 +163,7 @@ export function MembersTab({ members, isOwner }: MembersTabProps) {
         {filteredMembers.length > 0 ? (
           <div className="flex flex-col gap-2">
             {filteredMembers.map((member) => {
-              const isCurrentUser = member.id === MOCK_CURRENT_USER_ID;
+              const isCurrentUser = member.id === currentUserId;
               const canManage = isOwner && !isCurrentUser;
 
               return (

--- a/src/components/groups/tabs/MembersTab.tsx
+++ b/src/components/groups/tabs/MembersTab.tsx
@@ -1,32 +1,33 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { RemoveMemberDialog } from '@/components/groups/RemoveMemberDialog';
+import { useRemoveGroupMember } from '@/lib/hooks/useGroupMembers';
 import { type GroupMember, type GroupMemberRole } from '@/lib/types/group';
 import { cn } from '@/lib/utils';
 import {
-  MoreHorizontal,
   Crown,
   ShieldCheck,
-  ShieldOff,
   UserMinus,
   Search,
+  Users,
+  Eye,
+  Mail,
+  Calendar,
+  X,
 } from 'lucide-react';
 
 interface MembersTabProps {
   members: GroupMember[];
   isOwner: boolean;
   currentUserId: string;
+  groupId: string;
+  onMemberRemoved?: () => void;
 }
 
 type RoleFilterType = 'ALL' | GroupMemberRole;
@@ -35,23 +36,30 @@ export function MembersTab({
   members,
   isOwner,
   currentUserId,
+  groupId,
+  onMemberRemoved,
 }: MembersTabProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [roleFilter, setRoleFilter] = useState<RoleFilterType>('ALL');
+  const [memberToRemove, setMemberToRemove] = useState<GroupMember | null>(
+    null
+  );
+  const [memberToView, setMemberToView] = useState<GroupMember | null>(null);
 
-  // Filter members based on search query and role filter
+  const removeMember = useRemoveGroupMember();
+
   const filteredMembers = useMemo(() => {
     let filtered = members;
 
-    // Apply search filter (case-insensitive substring match on name)
     if (searchQuery.trim()) {
       const query = searchQuery.trim().toLowerCase();
-      filtered = filtered.filter((member) =>
-        member.name.toLowerCase().includes(query)
+      filtered = filtered.filter(
+        (member) =>
+          member.name.toLowerCase().includes(query) ||
+          member.email.toLowerCase().includes(query)
       );
     }
 
-    // Apply role filter
     if (roleFilter !== 'ALL') {
       filtered = filtered.filter((member) => member.role === roleFilter);
     }
@@ -59,25 +67,27 @@ export function MembersTab({
     return filtered;
   }, [members, searchQuery, roleFilter]);
 
-  const handlePromoteToAdmin = (memberId: string) => {
-    console.log('Promote to admin:', memberId);
-    // TODO: Implement API call
-  };
+  const handleConfirmRemove = useCallback(() => {
+    if (!memberToRemove) return;
 
-  const handleRemoveAdmin = (memberId: string) => {
-    console.log('Remove admin:', memberId);
-    // TODO: Implement API call
-  };
-
-  const handleRemoveMember = (memberId: string) => {
-    console.log('Remove member:', memberId);
-    // TODO: Implement API call
-  };
+    removeMember.mutate(
+      { groupId, email: memberToRemove.email },
+      {
+        onSuccess: () => {
+          setMemberToRemove(null);
+          onMemberRemoved?.();
+        },
+        onError: () => {
+          // Keep dialog open so user can retry or cancel
+        },
+      }
+    );
+  }, [memberToRemove, groupId, removeMember, onMemberRemoved]);
 
   const formatJoinDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
+    return new Date(dateString).toLocaleDateString('en-US', {
       month: 'short',
+      day: 'numeric',
       year: 'numeric',
     });
   };
@@ -90,202 +100,319 @@ export function MembersTab({
     return name.slice(0, 2).toUpperCase();
   };
 
+  const getRoleBadge = (role: GroupMemberRole) => {
+    if (role === 'OWNER') {
+      return (
+        <Badge
+          variant="outline"
+          className="flex items-center gap-1 border-amber-200 bg-amber-50 text-amber-700"
+        >
+          <Crown className="h-3 w-3" />
+          Owner
+        </Badge>
+      );
+    }
+    if (role === 'ADMIN') {
+      return (
+        <Badge
+          variant="outline"
+          className="flex items-center gap-1 border-blue-200 bg-blue-50 text-blue-700"
+        >
+          <ShieldCheck className="h-3 w-3" />
+          Admin
+        </Badge>
+      );
+    }
+    return (
+      <Badge
+        variant="outline"
+        className="border-gray-200 bg-gray-50 text-gray-600"
+      >
+        Member
+      </Badge>
+    );
+  };
+
   return (
-    <div className="flex flex-col">
-      {/* Search and Filter Controls */}
-      <div className="border-b border-gray-100 px-5 py-4">
-        {/* Search Input */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-          <Input
-            type="text"
-            placeholder="Search members by name..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9 pr-3"
-          />
-        </div>
-
-        {/* Role Filter Buttons */}
-        <div className="mt-3 flex items-center gap-2">
-          <span className="text-xs font-medium text-gray-600">Role:</span>
-          <div className="flex gap-1">
-            <button
-              onClick={() => setRoleFilter('ALL')}
-              className={cn(
-                'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-                roleFilter === 'ALL'
-                  ? 'bg-gray-900 text-white'
-                  : 'text-gray-700 hover:bg-gray-100'
-              )}
-            >
-              All
-            </button>
-            <button
-              onClick={() => setRoleFilter('OWNER')}
-              className={cn(
-                'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-                roleFilter === 'OWNER'
-                  ? 'bg-gray-900 text-white'
-                  : 'text-gray-700 hover:bg-gray-100'
-              )}
-            >
-              Owner
-            </button>
-            <button
-              onClick={() => setRoleFilter('ADMIN')}
-              className={cn(
-                'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-                roleFilter === 'ADMIN'
-                  ? 'bg-gray-900 text-white'
-                  : 'text-gray-700 hover:bg-gray-100'
-              )}
-            >
-              Admin
-            </button>
-            <button
-              onClick={() => setRoleFilter('MEMBER')}
-              className={cn(
-                'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-                roleFilter === 'MEMBER'
-                  ? 'bg-gray-900 text-white'
-                  : 'text-gray-700 hover:bg-gray-100'
-              )}
-            >
-              Member
-            </button>
+    <>
+      <div className="flex flex-col">
+        {/* Header with member count */}
+        <div className="flex items-center justify-between border-b border-gray-100 px-5 py-3">
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-gray-500" />
+            <span className="text-sm font-semibold text-gray-900">Members</span>
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+              {members.length}
+            </span>
           </div>
         </div>
-      </div>
 
-      {/* Members List */}
-      <div className="flex-1 px-5 py-4">
-        {filteredMembers.length > 0 ? (
-          <div className="flex flex-col gap-2">
-            {filteredMembers.map((member) => {
-              const isCurrentUser = member.id === currentUserId;
-              const canManage = isOwner && !isCurrentUser;
+        {/* Search and Filter Controls */}
+        <div className="border-b border-gray-100 px-5 py-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <Input
+              type="text"
+              placeholder="Search by name or email..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-9 pr-3"
+            />
+          </div>
 
-              return (
-                <div
-                  key={member.id}
-                  className="flex items-center justify-between rounded-lg px-3 py-2.5 transition-colors hover:bg-gray-50"
-                >
-                  <div className="flex items-center gap-3">
-                    <Avatar className="h-9 w-9">
-                      {member.avatarUrl ? (
-                        <AvatarImage src={member.avatarUrl} alt={member.name} />
-                      ) : null}
-                      <AvatarFallback className="bg-gradient-to-br from-skolaroid-blue to-blue-600 text-xs text-white">
-                        {getMemberInitials(member.name)}
-                      </AvatarFallback>
-                    </Avatar>
-
-                    <div className="flex flex-col">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-gray-900">
-                          {member.name}
-                        </span>
-                        {member.role === 'OWNER' && (
-                          <Badge
-                            variant="outline"
-                            className="flex items-center gap-1 border-amber-200 bg-amber-50 text-amber-700"
-                          >
-                            <Crown className="h-3 w-3" />
-                            Owner
-                          </Badge>
-                        )}
-                        {member.role === 'ADMIN' && (
-                          <Badge
-                            variant="outline"
-                            className="flex items-center gap-1 border-blue-200 bg-blue-50 text-blue-700"
-                          >
-                            <ShieldCheck className="h-3 w-3" />
-                            Admin
-                          </Badge>
-                        )}
-                      </div>
-                      <span className="text-xs text-gray-500">
-                        Joined {formatJoinDate(member.joinedAt)}
-                      </span>
-                    </div>
-                  </div>
-
-                  {canManage && (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8 shrink-0"
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-48">
-                        {member.role === 'MEMBER' && (
-                          <>
-                            <DropdownMenuItem
-                              onClick={() => handlePromoteToAdmin(member.id)}
-                            >
-                              <ShieldCheck className="mr-2 h-4 w-4" />
-                              Promote to Admin
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                          </>
-                        )}
-                        {member.role === 'ADMIN' && (
-                          <>
-                            <DropdownMenuItem
-                              onClick={() => handleRemoveAdmin(member.id)}
-                            >
-                              <ShieldOff className="mr-2 h-4 w-4" />
-                              Remove Admin
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                          </>
-                        )}
-                        <DropdownMenuItem
-                          onClick={() => handleRemoveMember(member.id)}
-                          className="text-red-600 focus:text-red-600"
-                        >
-                          <UserMinus className="mr-2 h-4 w-4" />
-                          Remove from Group
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+          <div className="mt-3 flex items-center gap-2">
+            <span className="text-xs font-medium text-gray-600">Role:</span>
+            <div className="flex gap-1">
+              {(['ALL', 'OWNER', 'ADMIN', 'MEMBER'] as const).map((role) => (
+                <button
+                  key={role}
+                  onClick={() => setRoleFilter(role)}
+                  className={cn(
+                    'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                    roleFilter === role
+                      ? 'bg-gray-900 text-white'
+                      : 'text-gray-700 hover:bg-gray-100'
                   )}
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="flex flex-col items-center justify-center py-12">
-            <div className="rounded-full bg-gray-100 p-4">
-              <Search className="h-6 w-6 text-gray-400" />
+                >
+                  {role === 'ALL'
+                    ? 'All'
+                    : role.charAt(0) + role.slice(1).toLowerCase()}
+                </button>
+              ))}
             </div>
-            <h4 className="mt-3 text-sm font-medium text-gray-900">
-              No members found
-            </h4>
-            <p className="mt-1 text-center text-sm text-gray-600">
-              {searchQuery.trim()
-                ? `No members match "${searchQuery}"`
-                : 'No members with this role'}
-            </p>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="mt-3"
-              onClick={() => {
-                setSearchQuery('');
-                setRoleFilter('ALL');
-              }}
-            >
-              Clear filters
-            </Button>
           </div>
-        )}
+        </div>
+
+        {/* Members Table */}
+        <div className="flex-1 overflow-x-auto">
+          {filteredMembers.length > 0 ? (
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-gray-100 text-left">
+                  <th className="px-5 py-2.5 text-xs font-medium uppercase tracking-wider text-gray-400">
+                    Member
+                  </th>
+                  <th className="px-3 py-2.5 text-xs font-medium uppercase tracking-wider text-gray-400">
+                    Role
+                  </th>
+                  <th className="hidden px-3 py-2.5 text-xs font-medium uppercase tracking-wider text-gray-400 md:table-cell">
+                    Joined
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-gray-400">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {filteredMembers.map((member) => {
+                  const isCurrentUser = member.id === currentUserId;
+                  const canRemove =
+                    isOwner && !isCurrentUser && member.role !== 'OWNER';
+
+                  return (
+                    <tr
+                      key={member.id}
+                      className="transition-colors hover:bg-gray-50/50"
+                    >
+                      {/* Member info */}
+                      <td className="px-5 py-3">
+                        <div className="flex items-center gap-3">
+                          <Avatar className="h-8 w-8">
+                            {member.avatarUrl ? (
+                              <AvatarImage
+                                src={member.avatarUrl}
+                                alt={member.name}
+                              />
+                            ) : null}
+                            <AvatarFallback className="bg-gradient-to-br from-skolaroid-blue to-blue-600 text-xs text-white">
+                              {getMemberInitials(member.name)}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium text-gray-900">
+                              {member.name}
+                              {isCurrentUser && (
+                                <span className="ml-1 text-xs text-gray-400">
+                                  (you)
+                                </span>
+                              )}
+                            </p>
+                            <p className="truncate text-xs text-gray-500">
+                              {member.email}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+
+                      {/* Role */}
+                      <td className="px-3 py-3">{getRoleBadge(member.role)}</td>
+
+                      {/* Joined date */}
+                      <td className="hidden px-3 py-3 md:table-cell">
+                        <span className="text-xs text-gray-500">
+                          {formatJoinDate(member.joinedAt)}
+                        </span>
+                      </td>
+
+                      {/* Actions */}
+                      <td className="px-3 py-3 text-right">
+                        <div className="flex items-center justify-end gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            onClick={() => setMemberToView(member)}
+                            title="View details"
+                          >
+                            <Eye className="h-3.5 w-3.5 text-gray-500" />
+                          </Button>
+                          {canRemove && (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7 text-red-500 hover:bg-red-50 hover:text-red-600"
+                              onClick={() => setMemberToRemove(member)}
+                              title="Remove member"
+                            >
+                              <UserMinus className="h-3.5 w-3.5" />
+                            </Button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-12">
+              <div className="rounded-full bg-gray-100 p-4">
+                <Search className="h-6 w-6 text-gray-400" />
+              </div>
+              <h4 className="mt-3 text-sm font-medium text-gray-900">
+                No members found
+              </h4>
+              <p className="mt-1 text-center text-sm text-gray-600">
+                {searchQuery.trim()
+                  ? `No members match "${searchQuery}"`
+                  : 'No members with this role'}
+              </p>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-3"
+                onClick={() => {
+                  setSearchQuery('');
+                  setRoleFilter('ALL');
+                }}
+              >
+                Clear filters
+              </Button>
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+
+      {/* Remove Member Confirmation */}
+      <RemoveMemberDialog
+        open={!!memberToRemove}
+        onOpenChange={(open) => {
+          if (!open) setMemberToRemove(null);
+        }}
+        memberName={memberToRemove?.name ?? ''}
+        isLoading={removeMember.isPending}
+        onConfirm={handleConfirmRemove}
+      />
+
+      {/* Member Detail Dialog */}
+      <Dialog
+        open={!!memberToView}
+        onOpenChange={(open) => {
+          if (!open) setMemberToView(null);
+        }}
+      >
+        <DialogContent
+          className="max-w-sm gap-0 overflow-hidden rounded-2xl border-gray-100 p-0 shadow-2xl"
+          showCloseButton={false}
+        >
+          <DialogTitle className="sr-only">
+            {memberToView?.name ?? 'Member'} Details
+          </DialogTitle>
+
+          {memberToView && (
+            <div className="flex flex-col">
+              {/* Header */}
+              <div className="flex items-center justify-between border-b border-gray-100 px-5 py-3.5">
+                <h2 className="text-sm font-semibold text-gray-900">
+                  Member Details
+                </h2>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => setMemberToView(null)}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+
+              {/* Profile */}
+              <div className="flex flex-col items-center px-6 py-6">
+                <Avatar className="h-16 w-16">
+                  {memberToView.avatarUrl ? (
+                    <AvatarImage
+                      src={memberToView.avatarUrl}
+                      alt={memberToView.name}
+                    />
+                  ) : null}
+                  <AvatarFallback className="bg-gradient-to-br from-skolaroid-blue to-blue-600 text-lg text-white">
+                    {getMemberInitials(memberToView.name)}
+                  </AvatarFallback>
+                </Avatar>
+                <h3 className="mt-3 text-base font-semibold text-gray-900">
+                  {memberToView.name}
+                </h3>
+                <div className="mt-1.5">{getRoleBadge(memberToView.role)}</div>
+              </div>
+
+              {/* Details */}
+              <div className="space-y-3 border-t border-gray-100 px-6 py-4">
+                <div className="flex items-center gap-3">
+                  <Mail size={15} className="shrink-0 text-gray-400" />
+                  <span className="truncate text-sm text-gray-600">
+                    {memberToView.email}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Calendar size={15} className="shrink-0 text-gray-400" />
+                  <span className="text-sm text-gray-600">
+                    Joined {formatJoinDate(memberToView.joinedAt)}
+                  </span>
+                </div>
+              </div>
+
+              {/* Remove action for owner */}
+              {isOwner &&
+                memberToView.id !== currentUserId &&
+                memberToView.role !== 'OWNER' && (
+                  <div className="border-t border-gray-100 px-6 py-4">
+                    <Button
+                      variant="outline"
+                      className="w-full border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+                      onClick={() => {
+                        setMemberToRemove(memberToView);
+                        setMemberToView(null);
+                      }}
+                    >
+                      <UserMinus className="mr-2 h-4 w-4" />
+                      Remove from Group
+                    </Button>
+                  </div>
+                )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/lib/types/group.ts
+++ b/src/lib/types/group.ts
@@ -14,6 +14,7 @@ export type GroupMemberRole = 'OWNER' | 'ADMIN' | 'MEMBER';
 export interface GroupMember {
   id: string;
   name: string;
+  email: string;
   avatarUrl?: string | null;
   role: GroupMemberRole;
   joinedAt: string; // ISO date string
@@ -86,6 +87,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-001',
         name: 'You (Owner)',
+        email: 'you@example.com',
         avatarUrl: null,
         role: 'OWNER',
         joinedAt: '2024-01-15T08:00:00.000Z',
@@ -93,6 +95,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-002',
         name: 'Maria Santos',
+        email: 'maria.santos@example.com',
         avatarUrl: null,
         role: 'ADMIN',
         joinedAt: '2024-01-16T09:00:00.000Z',
@@ -100,6 +103,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-003',
         name: 'Juan dela Cruz',
+        email: 'juan.delacruz@example.com',
         avatarUrl: null,
         role: 'MEMBER',
         joinedAt: '2024-01-17T10:00:00.000Z',
@@ -107,6 +111,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-004',
         name: 'Ana Reyes',
+        email: 'ana.reyes@example.com',
         avatarUrl: null,
         role: 'MEMBER',
         joinedAt: '2024-01-18T11:00:00.000Z',
@@ -114,6 +119,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-005',
         name: 'Carlos Mendoza',
+        email: 'carlos.mendoza@example.com',
         avatarUrl: null,
         role: 'MEMBER',
         joinedAt: '2024-01-19T12:00:00.000Z',
@@ -135,6 +141,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-002',
         name: 'Maria Santos',
+        email: 'maria.santos@example.com',
         avatarUrl: null,
         role: 'OWNER',
         joinedAt: '2024-02-01T08:00:00.000Z',
@@ -142,6 +149,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-001',
         name: 'You',
+        email: 'you@example.com',
         avatarUrl: null,
         role: 'MEMBER',
         joinedAt: '2024-02-05T09:00:00.000Z',
@@ -149,6 +157,7 @@ export const MOCK_GROUPS: Group[] = [
       {
         id: 'user-006',
         name: 'Pedro Ramos',
+        email: 'pedro.ramos@example.com',
         avatarUrl: null,
         role: 'MEMBER',
         joinedAt: '2024-02-06T10:00:00.000Z',


### PR DESCRIPTION
1. group.ts — Added email field to GroupMember interface and mock data so members can be identified for API calls.

2. RemoveMemberDialog.tsx (new) — Confirmation dialog matching the project's existing modal style (LeaveGroupModal pattern). Shows the member name, loading state, and cancel/remove buttons.

3. MembersTab.tsx — Complete rewrite:

- Table layout with columns: Member (avatar + name + email), Role (badge), Joined date, Actions
- Member count displayed in the header with a count badge
- View member details — Eye icon opens a detail dialog showing avatar, name, email, role, join date
- Remove members — Red trash icon (owner-only, not on self/other owners) opens RemoveMemberDialog, wired to useRemoveGroupMember hook with real API call
- Search now filters by name and email


4. GroupPanel.tsx — Migrated from mock data to real API:

- Uses useUserGroups() to fetch the group list
- Uses useGroupById() for selected group details
- Uses useDeleteGroup() and useRemoveGroupMember() for real mutations
- Helper functions toGroup() / toGroupMember() transform API responses to frontend types
- Auto-selects first group, shows loading spinner, refetches after member removal

5. index.ts — Added RemoveMemberDialog export.
