### PR TITLE
Scrum 65 reflect user name on the memory uploaded

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,32 +197,48 @@ export function useData() {
 
 **When**: Any component that fetches or mutates data.
 
-### 3. Create Service Layer Functions
+### 3. Service Layer: Extract When Complex
 
-Don't put business logic in API routes. Extract to a service:
+Extract business logic to `src/services/` when it involves **non-trivial logic** — multi-step queries, cursor pagination, aggregations, or anything that would benefit from reuse or isolated testing. Simple CRUD operations (a single `prisma.create`, `prisma.update`, or `prisma.delete`) can stay inlined in the API route.
 
 ```typescript
-// ✅ Good
-// src/services/user.ts
-export async function createUser(data: CreateUserInput) {
-  // Validate business rules
-  const existingUser = await prisma.user.findUnique({
-    where: { email: data.email },
+// ✅ Simple CRUD — inline in route (no service needed)
+// src/app/api/prisma/memory/comment/create/route.ts
+const comment = await prisma.memoryComment.create({
+  data: { memoryId, authorId, content },
+  include: {
+    author: { select: { id: true, firstName: true, lastName: true } },
+  },
+});
+return Response.json({ success: true, data: comment });
+
+// ✅ Complex logic — extract to service
+// src/services/get-comments-service.ts
+export async function getCommentsService(
+  memoryId: string,
+  limit: number,
+  cursor?: string
+) {
+  const rows = await prisma.memoryComment.findMany({
+    where: { memoryId, deletedAt: null },
+    take: limit + 1, // fetch one extra to determine hasMore
+    ...(cursor && { skip: 1, cursor: { id: cursor } }),
+    orderBy: { createdAt: 'desc' },
+    include: {
+      author: { select: { id: true, firstName: true, lastName: true } },
+    },
   });
-  if (existingUser) throw new Error('User already exists');
-
-  return prisma.user.create({ data });
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, -1) : rows;
+  return {
+    items,
+    nextCursor: hasMore ? items[items.length - 1].id : null,
+    hasMore,
+  };
 }
-
-// src/app/api/users/create/route.ts
-const result = createUserSchema.safeParse(body);
-if (!result.success)
-  return Response.json({ error: result.error }, { status: 400 });
-const user = await createUser(result.data);
-return Response.json(user);
 ```
 
-**When**: Any logic that might be reused or tested separately.
+**Rule of thumb**: if the Prisma call fits in ~3 lines and has no branching logic, keep it in the route. If it involves pagination, multi-table coordination, or business rules, extract it.
 
 ### 4. Use Type Inference from Zod
 
@@ -256,10 +272,10 @@ export type User = z.infer<typeof userSchema>;
 - Every API route should validate input
 - Invalid data should never reach your database
 
-❌ **Don't put business logic in API routes**
+❌ **Don't put complex business logic in API routes**
 
-- Extract to service layer
-- Makes testing and reuse easier
+- Extract to service layer when logic is non-trivial (pagination, multi-step queries)
+- Simple single-call CRUD can stay inlined in the route
 
 ❌ **Don't create useState for loading/error states**
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
-    "prepare": "husky",
+    "prepare": "husky && prisma generate",
     "migrate:prod": "npx dotenv -e .env.production -- prisma migrate deploy",
     "migrate:resolve": "npx dotenv -e .env.production -- prisma migrate resolve"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
-    "prepare": "husky && prisma generate",
+    "prepare": "husky",
     "migrate:prod": "npx dotenv -e .env.production -- prisma migrate deploy",
     "migrate:resolve": "npx dotenv -e .env.production -- prisma migrate resolve"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model User {
   // Relations
   memories       Memory[]
   votes          MemoryVote[]
+  comments       MemoryComment[]
   groups         PrivateGroup[] @relation("GroupMembers")
   createdGroups  PrivateGroup[] @relation("GroupCreator")
   
@@ -134,6 +135,7 @@ model Memory {
   // Relations
   tags           Tag[]            @relation("MemoryTags")
   votes          MemoryVote[]
+  comments       MemoryComment[]
 
   // Private group (required when visibility = GROUP_ONLY)
   privateGroupId String?          @db.Uuid
@@ -168,6 +170,27 @@ model Memory {
   @@index([deletedAt])
   @@index([createdAt]) // For chronological queries
   @@index([privateGroupId])
+}
+
+// ============================================================================
+// MEMORY COMMENT SYSTEM
+// ============================================================================
+
+model MemoryComment {
+  id        String    @id @default(uuid()) @db.Uuid
+  content   String    @db.Text
+  memoryId  String    @db.Uuid
+  memory    Memory    @relation(fields: [memoryId], references: [id], onDelete: Cascade)
+  authorId  String    @db.Uuid
+  author    User      @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  deletedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([memoryId])
+  @@index([authorId])
+  @@index([createdAt])
+  @@index([deletedAt])
 }
 
 // ============================================================================

--- a/src/app/api/prisma/memory/comment/[commentId]/delete/route.ts
+++ b/src/app/api/prisma/memory/comment/[commentId]/delete/route.ts
@@ -29,7 +29,6 @@ export async function DELETE(
     }
 
     // ── 2. Fetch comment + requesting user's role ──────────────────────────
-    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
     const [comment, dbUser] = await Promise.all([
       // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
       prisma.memoryComment.findUnique({

--- a/src/app/api/prisma/memory/comment/[commentId]/delete/route.ts
+++ b/src/app/api/prisma/memory/comment/[commentId]/delete/route.ts
@@ -30,7 +30,6 @@ export async function DELETE(
 
     // ── 2. Fetch comment + requesting user's role ──────────────────────────
     const [comment, dbUser] = await Promise.all([
-      // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
       prisma.memoryComment.findUnique({
         where: { id: commentId, deletedAt: null },
         select: { id: true, authorId: true },
@@ -70,7 +69,6 @@ export async function DELETE(
     }
 
     // ── 4. Soft delete ─────────────────────────────────────────────────────
-    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
     await prisma.memoryComment.update({
       where: { id: commentId },
       data: { deletedAt: new Date() },

--- a/src/app/api/prisma/memory/comment/[commentId]/delete/route.ts
+++ b/src/app/api/prisma/memory/comment/[commentId]/delete/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * DELETE /api/prisma/memory/comment/[commentId]/delete
+ *
+ * Soft-deletes a comment by setting deletedAt.
+ * Only the comment author or an ADMIN may delete.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ commentId: string }> }
+) {
+  try {
+    const { commentId } = await params;
+
+    // ── 1. Authenticate ────────────────────────────────────────────────────
+    const supabase = await createClient();
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, message: 'Not authenticated' },
+        { status: 401 }
+      );
+    }
+
+    // ── 2. Fetch comment + requesting user's role ──────────────────────────
+    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
+    const [comment, dbUser] = await Promise.all([
+      // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
+      prisma.memoryComment.findUnique({
+        where: { id: commentId, deletedAt: null },
+        select: { id: true, authorId: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: authUser.id },
+        select: { id: true, role: true },
+      }),
+    ]);
+
+    if (!comment) {
+      return NextResponse.json(
+        { success: false, message: 'Comment not found' },
+        { status: 404 }
+      );
+    }
+
+    if (!dbUser) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Complete onboarding before performing this action',
+        },
+        { status: 403 }
+      );
+    }
+
+    // ── 3. Authorise — author or admin only ────────────────────────────────
+    const isAuthor = comment.authorId === dbUser.id;
+    const isAdmin = dbUser.role === 'ADMIN';
+
+    if (!isAuthor && !isAdmin) {
+      return NextResponse.json(
+        { success: false, message: 'Not authorised to delete this comment' },
+        { status: 403 }
+      );
+    }
+
+    // ── 4. Soft delete ─────────────────────────────────────────────────────
+    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
+    await prisma.memoryComment.update({
+      where: { id: commentId },
+      data: { deletedAt: new Date() },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Comment deleted',
+    });
+  } catch (err) {
+    console.error('[comment/delete] unexpected error:', err);
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Unable to delete comment. Please try again.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/prisma/memory/comment/create/route.ts
+++ b/src/app/api/prisma/memory/comment/create/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import { createCommentSchema } from '@/lib/schemas';
+
+/**
+ * Resolves the authenticated user for this request.
+ * Mirrors the pattern in vote/toggle/route.ts — dev seed-user fallback included.
+ */
+async function resolveUser(
+  isDev: boolean
+): Promise<{ userId: string } | { error: NextResponse }> {
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+
+  if (authUser) {
+    const dbUser = await prisma.user.findUnique({
+      where: { id: authUser.id },
+      select: { id: true },
+    });
+
+    if (!dbUser) {
+      return {
+        error: NextResponse.json(
+          { success: false, message: 'Complete onboarding before commenting' },
+          { status: 403 }
+        ),
+      };
+    }
+
+    return { userId: dbUser.id };
+  }
+
+  if (isDev) {
+    const seedUser = await prisma.user.findUnique({
+      where: { email: 'seed@skolaroid.dev' },
+      select: { id: true },
+    });
+
+    if (seedUser) return { userId: seedUser.id };
+  }
+
+  return {
+    error: NextResponse.json(
+      { success: false, message: 'Not authenticated' },
+      { status: 401 }
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  const isDev = process.env.NODE_ENV === 'development';
+
+  try {
+    // ── 1. Auth ────────────────────────────────────────────────────────────
+    const resolved = await resolveUser(isDev);
+    if ('error' in resolved) return resolved.error;
+    const { userId } = resolved;
+
+    // ── 2. Validate body ───────────────────────────────────────────────────
+    const body = await request.json();
+    const parsed = createCommentSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? 'Validation failed',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { memoryId, content } = parsed.data;
+
+    // ── 3. Create comment ──────────────────────────────────────────────────
+    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
+    const comment = await prisma.memoryComment.create({
+      data: { memoryId, authorId: userId, content },
+      select: {
+        id: true,
+        content: true,
+        memoryId: true,
+        authorId: true,
+        author: { select: { id: true, firstName: true, lastName: true } },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Comment created',
+      data: comment,
+    });
+  } catch (err) {
+    console.error('[comment/create] unexpected error:', err);
+    return NextResponse.json(
+      { success: false, message: 'Unable to post comment. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/prisma/memory/comment/create/route.ts
+++ b/src/app/api/prisma/memory/comment/create/route.ts
@@ -78,7 +78,6 @@ export async function POST(request: NextRequest) {
     const { memoryId, content } = parsed.data;
 
     // ── 3. Create comment ──────────────────────────────────────────────────
-    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
     const comment = await prisma.memoryComment.create({
       data: { memoryId, authorId: userId, content },
       select: {

--- a/src/app/api/prisma/memory/comment/get/route.ts
+++ b/src/app/api/prisma/memory/comment/get/route.ts
@@ -33,7 +33,6 @@ export async function GET(request: NextRequest) {
     );
 
     // ── 3. Fetch total comment count (excluding soft-deleted) ──────────────
-    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
     const commentCount = await prisma.memoryComment.count({
       where: { memoryId, deletedAt: null },
     });

--- a/src/app/api/prisma/memory/comment/get/route.ts
+++ b/src/app/api/prisma/memory/comment/get/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getCommentsQuerySchema } from '@/lib/schemas';
+import { getCommentsService } from '@/services/get-comments-service';
+
+export async function GET(request: NextRequest) {
+  try {
+    // ── 1. Validate query params ───────────────────────────────────────────
+    const { searchParams } = request.nextUrl;
+    const parsed = getCommentsQuerySchema.safeParse({
+      memoryId: searchParams.get('memoryId'),
+      cursor: searchParams.get('cursor') ?? undefined,
+      limit: searchParams.get('limit') ?? undefined,
+    });
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? 'Validation failed',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { memoryId, cursor, limit } = parsed.data;
+
+    // ── 2. Fetch paginated comments ────────────────────────────────────────
+    const { items, nextCursor, hasMore } = await getCommentsService(
+      memoryId,
+      limit,
+      cursor
+    );
+
+    // ── 3. Fetch total comment count (excluding soft-deleted) ──────────────
+    // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
+    const commentCount = await prisma.memoryComment.count({
+      where: { memoryId, deletedAt: null },
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: { items, nextCursor, hasMore, commentCount },
+    });
+  } catch (err) {
+    console.error('[comment/get] unexpected error:', err);
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Unable to fetch comments. Please try again.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/prisma/memory/get-all-with-coordinates/route.ts
+++ b/src/app/api/prisma/memory/get-all-with-coordinates/route.ts
@@ -17,6 +17,7 @@ export async function GET() {
             longitude: true,
           },
         },
+        creator: { select: { firstName: true, lastName: true } },
         _count: { select: { votes: true } },
       },
       orderBy: { createdAt: 'desc' },

--- a/src/app/api/prisma/memory/get-by-location/route.ts
+++ b/src/app/api/prisma/memory/get-by-location/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: NextRequest) {
       include: {
         tags: true,
         location: { select: { id: true, buildingName: true } },
+        creator: { select: { firstName: true, lastName: true } },
         _count: { select: { votes: true } },
       },
       orderBy: { createdAt: 'desc' },

--- a/src/app/api/prisma/user/create/route.ts
+++ b/src/app/api/prisma/user/create/route.ts
@@ -92,8 +92,36 @@ export async function POST(request: NextRequest) {
       where: { id: authUser.id },
     });
     if (existingUser) {
+      if (authUser.app_metadata?.onboarded === true) {
+        return NextResponse.json(
+          { success: true, message: 'User already exists', user: existingUser },
+          { status: 200 }
+        );
+      }
+
+      // User exists in DB but app_metadata.onboarded not set — retry
+      const { error: metaError } = await markAsOnboarded(authUser.id);
+      if (metaError) {
+        console.error(
+          '[user/create] Failed to update app_metadata (retry):',
+          metaError.message
+        );
+        return NextResponse.json(
+          {
+            success: false,
+            message: 'User exists but failed to complete onboarding setup',
+            detail: metaError.message,
+          },
+          { status: 500 }
+        );
+      }
+
       return NextResponse.json(
-        { success: true, message: 'User already exists', user: existingUser },
+        {
+          success: true,
+          message: 'User already exists, onboarding completed',
+          user: existingUser,
+        },
         { status: 200 }
       );
     }

--- a/src/app/api/prisma/user/create/route.ts
+++ b/src/app/api/prisma/user/create/route.ts
@@ -116,6 +116,14 @@ export async function POST(request: NextRequest) {
         '[user/create] Failed to update app_metadata:',
         metaError.message
       );
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'User created but failed to complete onboarding setup',
+          detail: metaError.message,
+        },
+        { status: 500 }
+      );
     }
 
     return NextResponse.json({

--- a/src/app/api/prisma/user/create/route.ts
+++ b/src/app/api/prisma/user/create/route.ts
@@ -1,3 +1,4 @@
+import { createClient as createAdminClient } from '@supabase/supabase-js';
 import { prisma } from '@/lib/prisma';
 import { onboardUserSchema } from '@/lib/schemas';
 import { createClient } from '@/lib/supabase/server';
@@ -98,11 +99,10 @@ export async function POST(request: NextRequest) {
     });
 
     // ── 6. Mark user as onboarded in Supabase app_metadata ──────────
-    const { createClient: createAdminClient } =
-      await import('@supabase/supabase-js');
     const supabaseAdmin = createAdminClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } }
     );
     const { error: metaError } = await supabaseAdmin.auth.admin.updateUserById(
       authUser.id,

--- a/src/app/api/prisma/user/create/route.ts
+++ b/src/app/api/prisma/user/create/route.ts
@@ -4,6 +4,19 @@ import { onboardUserSchema } from '@/lib/schemas';
 import { createClient } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
 
+/** Set app_metadata.onboarded = true via the Supabase Admin API. */
+async function markAsOnboarded(userId: string) {
+  const supabaseAdmin = createAdminClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+  const { error } = await supabaseAdmin.auth.admin.updateUserById(userId, {
+    app_metadata: { onboarded: true },
+  });
+  return { error };
+}
+
 /**
  * POST /api/prisma/user/create
  *
@@ -99,18 +112,7 @@ export async function POST(request: NextRequest) {
     });
 
     // ── 6. Mark user as onboarded in Supabase app_metadata ──────────
-    const supabaseAdmin = createAdminClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-      { auth: { autoRefreshToken: false, persistSession: false } }
-    );
-    const { error: metaError } = await supabaseAdmin.auth.admin.updateUserById(
-      authUser.id,
-      {
-        app_metadata: { onboarded: true },
-      }
-    );
-
+    const { error: metaError } = await markAsOnboarded(authUser.id);
     if (metaError) {
       console.error(
         '[user/create] Failed to update app_metadata:',

--- a/src/components/map/CommentSection.tsx
+++ b/src/components/map/CommentSection.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { formatRelativeDate } from '@/lib/utils/format-date';
+import type { Comment } from '@/services/get-comments-service';
+
+interface CommentSectionProps {
+  comments: Comment[];
+  commentCount: number;
+  currentUserId: string | undefined;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  isSubmitting: boolean;
+  onSubmit: (content: string) => void;
+  onDelete: (commentId: string) => void;
+  onLoadMore: () => void;
+}
+
+export function CommentSection({
+  comments,
+  commentCount,
+  currentUserId,
+  hasMore,
+  isLoadingMore,
+  isSubmitting,
+  onSubmit,
+  onDelete,
+  onLoadMore,
+}: CommentSectionProps) {
+  return (
+    <div className="flex flex-1 flex-col gap-3">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <h3 className="text-base font-medium text-black">Comments</h3>
+        <span className="rounded-lg bg-gray-200 px-2 py-0.5 text-sm font-medium text-black">
+          {commentCount}
+        </span>
+      </div>
+
+      {/* Comment list */}
+      <div className="flex max-h-48 flex-col gap-3 overflow-y-auto pr-1">
+        {comments.map((comment) => (
+          <div key={comment.id} className="flex items-start gap-2">
+            <Avatar className="h-9 w-9 shrink-0">
+              <AvatarFallback className="bg-zinc-300 text-sm text-slate-600">
+                {comment.author.firstName.charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex-1">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-slate-800">
+                  {comment.author.firstName} {comment.author.lastName}
+                </p>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-gray-400">
+                    {formatRelativeDate(comment.createdAt)}
+                  </span>
+                  {currentUserId === comment.author.id && (
+                    <button
+                      onClick={() => onDelete(comment.id)}
+                      className="text-gray-400 transition-colors hover:text-red-500"
+                      aria-label="Delete comment"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </div>
+              </div>
+              <p className="text-sm text-slate-800">{comment.content}</p>
+            </div>
+          </div>
+        ))}
+
+        {/* Load more */}
+        {hasMore && (
+          <button
+            onClick={onLoadMore}
+            disabled={isLoadingMore}
+            className="text-xs text-skolaroid-blue hover:underline disabled:opacity-50"
+          >
+            {isLoadingMore ? 'Loading...' : 'Load more'}
+          </button>
+        )}
+      </div>
+
+      {/* Input — only shown when authenticated */}
+      {currentUserId && (
+        <CommentInput onSubmit={onSubmit} isSubmitting={isSubmitting} />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Isolated input so its own state doesn't re-render the comment list
+// ---------------------------------------------------------------------------
+
+function CommentInput({
+  onSubmit,
+  isSubmitting,
+}: {
+  onSubmit: (content: string) => void;
+  isSubmitting: boolean;
+}) {
+  const [text, setText] = useState('');
+
+  function handleSubmit() {
+    const trimmed = text.trim();
+    if (!trimmed || isSubmitting) return;
+    onSubmit(trimmed);
+    setText('');
+  }
+
+  return (
+    <div className="flex gap-2">
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+        placeholder="Write a comment…"
+        maxLength={2000}
+        className="flex-1 rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-slate-800 outline-none placeholder:text-gray-400 focus:border-skolaroid-blue"
+      />
+      <button
+        onClick={handleSubmit}
+        disabled={!text.trim() || isSubmitting}
+        className="rounded-lg bg-skolaroid-blue px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {isSubmitting ? 'Posting…' : 'Post'}
+      </button>
+    </div>
+  );
+}
+
+// useState is used inside CommentInput — import needed at file level
+import { useState } from 'react';

--- a/src/components/map/CommentSection.tsx
+++ b/src/components/map/CommentSection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { formatRelativeDate } from '@/lib/utils/format-date';
@@ -15,6 +16,10 @@ interface CommentSectionProps {
   onSubmit: (content: string) => void;
   onDelete: (commentId: string) => void;
   onLoadMore: () => void;
+  /** Controlled text value — when provided, CommentInput becomes controlled. */
+  commentText?: string;
+  /** Change handler for controlled text. */
+  onCommentTextChange?: (text: string) => void;
 }
 
 export function CommentSection({
@@ -27,6 +32,8 @@ export function CommentSection({
   onSubmit,
   onDelete,
   onLoadMore,
+  commentText,
+  onCommentTextChange,
 }: CommentSectionProps) {
   return (
     <div className="flex flex-1 flex-col gap-3">
@@ -86,24 +93,46 @@ export function CommentSection({
 
       {/* Input — only shown when authenticated */}
       {currentUserId && (
-        <CommentInput onSubmit={onSubmit} isSubmitting={isSubmitting} />
+        <CommentInput
+          onSubmit={onSubmit}
+          isSubmitting={isSubmitting}
+          controlledText={commentText}
+          onControlledTextChange={onCommentTextChange}
+        />
       )}
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Isolated input so its own state doesn't re-render the comment list
+// Isolated input — supports both uncontrolled (base page) and controlled
+// (overlay pages, display-only) modes via optional controlledText prop.
 // ---------------------------------------------------------------------------
 
 function CommentInput({
   onSubmit,
   isSubmitting,
+  controlledText,
+  onControlledTextChange,
 }: {
   onSubmit: (content: string) => void;
   isSubmitting: boolean;
+  controlledText?: string;
+  onControlledTextChange?: (text: string) => void;
 }) {
-  const [text, setText] = useState('');
+  const [internalText, setInternalText] = useState('');
+
+  // Use controlled value when provided, otherwise use internal state
+  const isControlled = controlledText !== undefined;
+  const text = isControlled ? controlledText : internalText;
+
+  function setText(value: string) {
+    if (isControlled) {
+      onControlledTextChange?.(value);
+    } else {
+      setInternalText(value);
+    }
+  }
 
   function handleSubmit() {
     const trimmed = text.trim();
@@ -133,6 +162,3 @@ function CommentInput({
     </div>
   );
 }
-
-// useState is used inside CommentInput — import needed at file level
-import { useState } from 'react';

--- a/src/components/map/MemoryDetailModal.tsx
+++ b/src/components/map/MemoryDetailModal.tsx
@@ -299,12 +299,12 @@ export function MemoryDetailModal({
   const authorInitial = 'M';
 
   function handleCommentSubmit(content: string) {
-    createComment.mutate({ memoryId: memory.id, content });
+    createComment.mutate({ memoryId: memory!.id, content });
     setCommentText('');
   }
 
   function handleCommentDelete(commentId: string) {
-    deleteComment.mutate({ commentId, memoryId: memory.id });
+    deleteComment.mutate({ commentId, memoryId: memory!.id });
   }
 
   // Whether covers should be visible (during open/close animations or closed state)

--- a/src/components/map/MemoryDetailModal.tsx
+++ b/src/components/map/MemoryDetailModal.tsx
@@ -6,6 +6,8 @@ import { Dialog, DialogTitle } from '@/components/ui/dialog';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import type { MemoryWithCoordinates } from '@/lib/hooks/useAllMemoriesWithCoordinates';
 import { ActionBar } from '@/components/map/ActionBar';
+import { CommentSection } from '@/components/map/CommentSection';
+import type { Comment } from '@/services/get-comments-service';
 import Image from 'next/image';
 import { useState, useEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -257,8 +259,16 @@ export function MemoryDetailModal({
   const authorInitial = 'M';
   const commentCount = 120;
 
-  const mockComments = [
-    { authorName: 'Kint Louise', subtitle: 'Covers collection', date: 'Today' },
+  const mockComments: Comment[] = [
+    {
+      id: 'mock-1',
+      content: 'Covers collection',
+      memoryId: '',
+      authorId: 'mock-author-1',
+      author: { id: 'mock-author-1', firstName: 'Kint', lastName: 'Louise' },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
   ];
 
   // Whether covers should be visible (during open/close animations or closed state)
@@ -484,43 +494,17 @@ export function MemoryDetailModal({
                           <ActionBar memory={baseRightMemory} />
 
                           {/* Comments section */}
-                          <div className="flex-1">
-                            <div className="mb-2 flex items-center gap-2">
-                              <h3 className="text-base font-medium text-black">
-                                Comments
-                              </h3>
-                              <span className="rounded-lg bg-gray-200 px-2 py-0.5 text-sm font-medium text-black">
-                                {commentCount}
-                              </span>
-                            </div>
-                            <div className="flex max-h-32 flex-col gap-3 overflow-y-auto pr-1">
-                              {mockComments.map((comment, idx) => (
-                                <div
-                                  key={idx}
-                                  className="flex items-start gap-2"
-                                >
-                                  <Avatar className="h-9 w-9">
-                                    <AvatarFallback className="bg-zinc-300 text-sm text-slate-600">
-                                      {comment.authorName.charAt(0)}
-                                    </AvatarFallback>
-                                  </Avatar>
-                                  <div className="flex-1">
-                                    <div className="flex items-center justify-between">
-                                      <p className="text-sm font-semibold text-slate-800">
-                                        {comment.authorName}
-                                      </p>
-                                      <span className="text-xs text-gray-400">
-                                        {comment.date}
-                                      </span>
-                                    </div>
-                                    <p className="text-sm text-slate-800">
-                                      {comment.subtitle}
-                                    </p>
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
+                          <CommentSection
+                            comments={mockComments}
+                            commentCount={commentCount}
+                            currentUserId={undefined}
+                            hasMore={false}
+                            isLoadingMore={false}
+                            isSubmitting={false}
+                            onSubmit={() => {}}
+                            onDelete={() => {}}
+                            onLoadMore={() => {}}
+                          />
 
                           {/* Spine rings on left edge of right page - scales when left page is flipping */}
                           <RightPageSpineRings
@@ -680,43 +664,17 @@ export function MemoryDetailModal({
                                 <ActionBar memory={memory} />
 
                                 {/* Comments section */}
-                                <div className="flex-1">
-                                  <div className="mb-2 flex items-center gap-2">
-                                    <h3 className="text-base font-medium text-black">
-                                      Comments
-                                    </h3>
-                                    <span className="rounded-lg bg-gray-200 px-2 py-0.5 text-sm font-medium text-black">
-                                      {commentCount}
-                                    </span>
-                                  </div>
-                                  <div className="flex max-h-32 flex-col gap-3 overflow-y-auto pr-1">
-                                    {mockComments.map((comment, idx) => (
-                                      <div
-                                        key={idx}
-                                        className="flex items-start gap-2"
-                                      >
-                                        <Avatar className="h-9 w-9">
-                                          <AvatarFallback className="bg-zinc-300 text-sm text-slate-600">
-                                            {comment.authorName.charAt(0)}
-                                          </AvatarFallback>
-                                        </Avatar>
-                                        <div className="flex-1">
-                                          <div className="flex items-center justify-between">
-                                            <p className="text-sm font-semibold text-slate-800">
-                                              {comment.authorName}
-                                            </p>
-                                            <span className="text-xs text-gray-400">
-                                              {comment.date}
-                                            </span>
-                                          </div>
-                                          <p className="text-sm text-slate-800">
-                                            {comment.subtitle}
-                                          </p>
-                                        </div>
-                                      </div>
-                                    ))}
-                                  </div>
-                                </div>
+                                <CommentSection
+                                  comments={mockComments}
+                                  commentCount={commentCount}
+                                  currentUserId={undefined}
+                                  hasMore={false}
+                                  isLoadingMore={false}
+                                  isSubmitting={false}
+                                  onSubmit={() => {}}
+                                  onDelete={() => {}}
+                                  onLoadMore={() => {}}
+                                />
 
                                 {/* Spine rings on left edge (back of left page shows right content) */}
                                 <RightPageSpineRings />
@@ -782,43 +740,17 @@ export function MemoryDetailModal({
                               <ActionBar memory={cachedMemory!} />
 
                               {/* Comments section */}
-                              <div className="flex-1">
-                                <div className="mb-2 flex items-center gap-2">
-                                  <h3 className="text-base font-medium text-black">
-                                    Comments
-                                  </h3>
-                                  <span className="rounded-lg bg-gray-200 px-2 py-0.5 text-sm font-medium text-black">
-                                    {commentCount}
-                                  </span>
-                                </div>
-                                <div className="flex max-h-32 flex-col gap-3 overflow-y-auto pr-1">
-                                  {mockComments.map((comment, idx) => (
-                                    <div
-                                      key={idx}
-                                      className="flex items-start gap-2"
-                                    >
-                                      <Avatar className="h-9 w-9">
-                                        <AvatarFallback className="bg-zinc-300 text-sm text-slate-600">
-                                          {comment.authorName.charAt(0)}
-                                        </AvatarFallback>
-                                      </Avatar>
-                                      <div className="flex-1">
-                                        <div className="flex items-center justify-between">
-                                          <p className="text-sm font-semibold text-slate-800">
-                                            {comment.authorName}
-                                          </p>
-                                          <span className="text-xs text-gray-400">
-                                            {comment.date}
-                                          </span>
-                                        </div>
-                                        <p className="text-sm text-slate-800">
-                                          {comment.subtitle}
-                                        </p>
-                                      </div>
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
+                              <CommentSection
+                                comments={mockComments}
+                                commentCount={commentCount}
+                                currentUserId={undefined}
+                                hasMore={false}
+                                isLoadingMore={false}
+                                isSubmitting={false}
+                                onSubmit={() => {}}
+                                onDelete={() => {}}
+                                onLoadMore={() => {}}
+                              />
 
                               {/* Spine rings on left edge */}
                               <RightPageSpineRings />

--- a/src/components/map/MemoryDetailModal.tsx
+++ b/src/components/map/MemoryDetailModal.tsx
@@ -253,8 +253,10 @@ export function MemoryDetailModal({
 
   if (!memory || !dateInfo) return null;
 
-  const authorName = 'Memory Author';
-  const authorInitial = 'M';
+  const authorName = memory.creator
+    ? `${memory.creator.firstName} ${memory.creator.lastName}`
+    : 'Unknown Author';
+  const authorInitial = authorName.charAt(0);
   const commentCount = 120;
 
   const mockComments = [

--- a/src/components/map/MemoryDetailModal.tsx
+++ b/src/components/map/MemoryDetailModal.tsx
@@ -7,9 +7,12 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import type { MemoryWithCoordinates } from '@/lib/hooks/useAllMemoriesWithCoordinates';
 import { ActionBar } from '@/components/map/ActionBar';
 import { CommentSection } from '@/components/map/CommentSection';
-import type { Comment } from '@/services/get-comments-service';
+import { useCommentsByMemory } from '@/lib/hooks/useCommentsByMemory';
+import { useCreateComment } from '@/lib/hooks/useCreateComment';
+import { useDeleteComment } from '@/lib/hooks/useDeleteComment';
+import { useUserAuth } from '@/lib/hooks/useUserAuth';
 import Image from 'next/image';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   coverLeftVariants,
@@ -167,6 +170,12 @@ export function MemoryDetailModal({
   const handleNext = () => {
     if (!hasNext || isFlipping || !onNext) return;
 
+    // Snapshot comment text and data for the overlay, then clear for the incoming page
+    carriedCommentText.current = commentText;
+    cachedCommentsRef.current = liveComments;
+    cachedCommentCountRef.current = liveCommentCount;
+    setCommentText('');
+
     // Cache current memory and orientation so the flipping page and base left page
     // stay stable while the new image loads
     setCachedMemory(memory);
@@ -191,6 +200,12 @@ export function MemoryDetailModal({
   // Handle PREVIOUS: left page flips over to the right, revealing new content underneath
   const handlePrevious = () => {
     if (!hasPrevious || isFlipping || !onPrevious) return;
+
+    // Snapshot comment text and data, then clear for the incoming page
+    carriedCommentText.current = commentText;
+    cachedCommentsRef.current = liveComments;
+    cachedCommentCountRef.current = liveCommentCount;
+    setCommentText('');
 
     // Cache current memory and orientation so the flipping page and base left page
     // stay stable while the new image loads
@@ -253,23 +268,44 @@ export function MemoryDetailModal({
     [cachedMemory]
   );
 
+  // ── Comment hooks (must be before any early return) ───────────────────────
+  const { user } = useUserAuth();
+  const {
+    data: commentsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useCommentsByMemory(memory?.id);
+  const createComment = useCreateComment();
+  const deleteComment = useDeleteComment();
+  const [commentText, setCommentText] = useState('');
+  const carriedCommentText = useRef('');
+
+  // Derive live comment data (safe to call before early return — just derives from query)
+  const liveComments = commentsData?.pages.flatMap((p) => p.data.items) ?? [];
+  const liveCommentCount = commentsData?.pages[0]?.data.commentCount ?? 0;
+
+  // Cached comments for flip overlays (same pattern as cachedMemory)
+  const cachedCommentsRef = useRef(liveComments);
+  const cachedCommentCountRef = useRef(liveCommentCount);
+
+  // Base page always uses live data; overlays use cached snapshots
+  const allComments = liveComments;
+  const commentCount = liveCommentCount;
+
   if (!memory || !dateInfo) return null;
 
   const authorName = 'Memory Author';
   const authorInitial = 'M';
-  const commentCount = 120;
 
-  const mockComments: Comment[] = [
-    {
-      id: 'mock-1',
-      content: 'Covers collection',
-      memoryId: '',
-      authorId: 'mock-author-1',
-      author: { id: 'mock-author-1', firstName: 'Kint', lastName: 'Louise' },
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-  ];
+  function handleCommentSubmit(content: string) {
+    createComment.mutate({ memoryId: memory.id, content });
+    setCommentText('');
+  }
+
+  function handleCommentDelete(commentId: string) {
+    deleteComment.mutate({ commentId, memoryId: memory.id });
+  }
 
   // Whether covers should be visible (during open/close animations or closed state)
   const showCovers = animationPhase !== 'open';
@@ -493,17 +529,43 @@ export function MemoryDetailModal({
                           {/* Action bar */}
                           <ActionBar memory={baseRightMemory} />
 
-                          {/* Comments section */}
+                          {/* Comments section — during prev flip, hold old text on exposed base */}
                           <CommentSection
-                            comments={mockComments}
-                            commentCount={commentCount}
-                            currentUserId={undefined}
-                            hasMore={false}
-                            isLoadingMore={false}
-                            isSubmitting={false}
-                            onSubmit={() => {}}
-                            onDelete={() => {}}
-                            onLoadMore={() => {}}
+                            comments={
+                              isFlipping && flipDirection === 'prev'
+                                ? cachedCommentsRef.current
+                                : allComments
+                            }
+                            commentCount={
+                              isFlipping && flipDirection === 'prev'
+                                ? cachedCommentCountRef.current
+                                : commentCount
+                            }
+                            currentUserId={user?.id}
+                            hasMore={
+                              isFlipping ? false : (hasNextPage ?? false)
+                            }
+                            isLoadingMore={
+                              isFlipping ? false : isFetchingNextPage
+                            }
+                            isSubmitting={
+                              isFlipping ? false : createComment.isPending
+                            }
+                            onSubmit={
+                              isFlipping ? () => {} : handleCommentSubmit
+                            }
+                            onDelete={
+                              isFlipping ? () => {} : handleCommentDelete
+                            }
+                            onLoadMore={isFlipping ? () => {} : fetchNextPage}
+                            commentText={
+                              isFlipping && flipDirection === 'prev'
+                                ? carriedCommentText.current
+                                : commentText
+                            }
+                            onCommentTextChange={
+                              isFlipping ? () => {} : setCommentText
+                            }
                           />
 
                           {/* Spine rings on left edge of right page - scales when left page is flipping */}
@@ -663,17 +725,19 @@ export function MemoryDetailModal({
                                 {/* Action bar */}
                                 <ActionBar memory={memory} />
 
-                                {/* Comments section */}
+                                {/* Comments section — PREV flip: cached comments, blank input */}
                                 <CommentSection
-                                  comments={mockComments}
-                                  commentCount={commentCount}
-                                  currentUserId={undefined}
+                                  comments={cachedCommentsRef.current}
+                                  commentCount={cachedCommentCountRef.current}
+                                  currentUserId={user?.id}
                                   hasMore={false}
                                   isLoadingMore={false}
                                   isSubmitting={false}
                                   onSubmit={() => {}}
                                   onDelete={() => {}}
                                   onLoadMore={() => {}}
+                                  commentText=""
+                                  onCommentTextChange={() => {}}
                                 />
 
                                 {/* Spine rings on left edge (back of left page shows right content) */}
@@ -739,17 +803,19 @@ export function MemoryDetailModal({
                               {/* Action bar */}
                               <ActionBar memory={cachedMemory!} />
 
-                              {/* Comments section */}
+                              {/* Comments section — NEXT flip: cached comments, carry snapshotted text */}
                               <CommentSection
-                                comments={mockComments}
-                                commentCount={commentCount}
-                                currentUserId={undefined}
+                                comments={cachedCommentsRef.current}
+                                commentCount={cachedCommentCountRef.current}
+                                currentUserId={user?.id}
                                 hasMore={false}
                                 isLoadingMore={false}
                                 isSubmitting={false}
                                 onSubmit={() => {}}
                                 onDelete={() => {}}
                                 onLoadMore={() => {}}
+                                commentText={carriedCommentText.current}
+                                onCommentTextChange={() => {}}
                               />
 
                               {/* Spine rings on left edge */}

--- a/src/lib/hooks/useCommentsByMemory.ts
+++ b/src/lib/hooks/useCommentsByMemory.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import type { Comment } from '@/services/get-comments-service';
+
+interface GetCommentsPage {
+  success: boolean;
+  data: {
+    items: Comment[];
+    nextCursor: string | null;
+    hasMore: boolean;
+    commentCount: number;
+  };
+}
+
+export function useCommentsByMemory(memoryId: string | undefined) {
+  return useInfiniteQuery({
+    queryKey: ['comments', memoryId],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ memoryId: memoryId! });
+      if (pageParam) params.set('cursor', pageParam);
+
+      const res = await fetch(`/api/prisma/memory/comment/get?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch comments');
+      return res.json() as Promise<GetCommentsPage>;
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.data.nextCursor ?? undefined,
+    enabled: !!memoryId,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/src/lib/hooks/useCreateComment.ts
+++ b/src/lib/hooks/useCreateComment.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface CreateCommentPayload {
+  memoryId: string;
+  content: string;
+}
+
+interface CreateCommentResponse {
+  success: boolean;
+  message: string;
+  data: {
+    id: string;
+    content: string;
+    memoryId: string;
+    authorId: string;
+    author: { id: string; firstName: string; lastName: string };
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
+export function useCreateComment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ memoryId, content }: CreateCommentPayload) => {
+      const res = await fetch('/api/prisma/memory/comment/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ memoryId, content }),
+      });
+
+      const json = (await res.json()) as CreateCommentResponse;
+
+      if (!res.ok) {
+        throw new Error(json.message ?? 'Failed to post comment');
+      }
+
+      return json;
+    },
+
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['comments', variables.memoryId],
+      });
+    },
+  });
+}

--- a/src/lib/hooks/useDeleteComment.ts
+++ b/src/lib/hooks/useDeleteComment.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface DeleteCommentPayload {
+  commentId: string;
+  memoryId: string; // needed for cache invalidation
+}
+
+interface DeleteCommentResponse {
+  success: boolean;
+  message: string;
+}
+
+export function useDeleteComment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ commentId }: DeleteCommentPayload) => {
+      const res = await fetch(
+        `/api/prisma/memory/comment/${commentId}/delete`,
+        { method: 'DELETE' }
+      );
+
+      const json = (await res.json()) as DeleteCommentResponse;
+
+      if (!res.ok) {
+        throw new Error(json.message ?? 'Failed to delete comment');
+      }
+
+      return json;
+    },
+
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['comments', variables.memoryId],
+      });
+    },
+  });
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -82,7 +82,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2024',
       },
     ],
-    _count: { votes: 12 },
+    _count: { votes: 12, comments: 0 },
   },
   {
     id: '10000000-0000-0000-0000-000000000002',
@@ -115,7 +115,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2024',
       },
     ],
-    _count: { votes: 24 },
+    _count: { votes: 24, comments: 0 },
   },
   {
     id: '10000000-0000-0000-0000-000000000003',
@@ -142,7 +142,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2025',
       },
     ],
-    _count: { votes: 3 },
+    _count: { votes: 3, comments: 0 },
   },
 
   // --- UP Main Library (2 memories) ---
@@ -182,7 +182,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2024',
       },
     ],
-    _count: { votes: 8 },
+    _count: { votes: 8, comments: 0 },
   },
   {
     id: '10000000-0000-0000-0000-000000000005',
@@ -214,7 +214,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2024',
       },
     ],
-    _count: { votes: 6 },
+    _count: { votes: 6, comments: 0 },
   },
 
   // --- AS Steps (2 memories) ---
@@ -254,7 +254,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2024',
       },
     ],
-    _count: { votes: 15 },
+    _count: { votes: 15, comments: 0 },
   },
   {
     id: '10000000-0000-0000-0000-000000000007',
@@ -286,7 +286,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2025',
       },
     ],
-    _count: { votes: 20 },
+    _count: { votes: 20, comments: 0 },
   },
 
   // --- Sunken Garden (1 memory) ---
@@ -326,7 +326,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2024',
       },
     ],
-    _count: { votes: 31 },
+    _count: { votes: 31, comments: 0 },
   },
 
   // --- Oblation Plaza — 2010s era (1 memory for cross-era testing) ---
@@ -361,7 +361,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2010',
       },
     ],
-    _count: { votes: 18 },
+    _count: { votes: 18, comments: 0 },
   },
 
   // --- AS Steps — 2010s era (1 memory for cross-era testing) ---
@@ -401,7 +401,7 @@ export const MOCK_MEMORIES = [
         slug: 'batch-2012',
       },
     ],
-    _count: { votes: 9 },
+    _count: { votes: 9, comments: 0 },
   },
 
   // --- College of Engineering (0 memories) ---

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -108,6 +108,41 @@ export type ToggleVoteInput = z.infer<typeof toggleVoteSchema>;
 export type VoteStatusQuery = z.infer<typeof voteStatusQuerySchema>;
 
 // ============================================================================
+// COMMENT SCHEMAS
+// ============================================================================
+
+export const MAX_COMMENT_LENGTH = 2000;
+
+/** Payload for creating a comment — authorId comes from server-side auth. */
+export const createCommentSchema = z.object({
+  memoryId: z.string().uuid('Invalid memory ID'),
+  content: z
+    .string()
+    .trim()
+    .min(1, 'Comment cannot be empty')
+    .max(
+      MAX_COMMENT_LENGTH,
+      `Comment must be ${MAX_COMMENT_LENGTH} characters or less`
+    ),
+});
+
+/** Query params for fetching comments on a memory (cursor-based pagination). */
+export const getCommentsQuerySchema = z.object({
+  memoryId: z.string().uuid('Invalid memory ID'),
+  cursor: z.string().uuid('Invalid cursor').optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+/** Payload for deleting a comment — checked against authorId server-side. */
+export const deleteCommentSchema = z.object({
+  commentId: z.string().uuid('Invalid comment ID'),
+});
+
+export type CreateCommentInput = z.infer<typeof createCommentSchema>;
+export type GetCommentsQuery = z.infer<typeof getCommentsQuerySchema>;
+export type DeleteCommentInput = z.infer<typeof deleteCommentSchema>;
+
+// ============================================================================
 // MEMORY TYPE EXPORTS
 // ============================================================================
 
@@ -176,7 +211,7 @@ export interface MemoryWithRelations {
   createdAt?: string;
   tags?: { id: string; name: string }[];
   location?: { buildingName: string };
-  _count?: { votes: number };
+  _count?: { votes: number; comments: number };
 }
 
 /** Visibility label mapping for display. */

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -176,6 +176,7 @@ export interface MemoryWithRelations {
   createdAt?: string;
   tags?: { id: string; name: string }[];
   location?: { buildingName: string };
+  creator?: { firstName: string; lastName: string } | null;
   _count?: { votes: number };
 }
 

--- a/src/lib/utils/format-date.ts
+++ b/src/lib/utils/format-date.ts
@@ -1,0 +1,21 @@
+/**
+ * Formats an ISO timestamp into a human-readable relative label.
+ * Examples: "Today", "Yesterday", "3d ago", "2mo ago", "1y ago"
+ */
+export function formatRelativeDate(iso: string | Date): string {
+  const date = typeof iso === 'string' ? new Date(iso) : iso;
+  const now = new Date();
+
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 30) return `${diffDays}d ago`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}mo ago`;
+
+  const diffYears = Math.floor(diffDays / 365);
+  return `${diffYears}y ago`;
+}

--- a/src/services/get-comments-service.ts
+++ b/src/services/get-comments-service.ts
@@ -39,7 +39,6 @@ export async function getCommentsService(
   limit: number,
   cursor?: string
 ): Promise<GetCommentsResult> {
-  // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
   const rows = await prisma.memoryComment.findMany({
     where: { memoryId, deletedAt: null },
     orderBy: { createdAt: 'desc' },

--- a/src/services/get-comments-service.ts
+++ b/src/services/get-comments-service.ts
@@ -1,0 +1,69 @@
+import { prisma } from '@/lib/prisma';
+
+export interface CommentAuthor {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface Comment {
+  id: string;
+  content: string;
+  memoryId: string;
+  authorId: string;
+  author: CommentAuthor;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface GetCommentsResult {
+  items: Comment[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+const AUTHOR_SELECT = { id: true, firstName: true, lastName: true } as const;
+
+/**
+ * Fetches comments for a memory using cursor-based pagination.
+ *
+ * Strategy: fetch `limit + 1` rows. If we get back more than `limit`,
+ * there is a next page — trim the extra row and use the last item's id
+ * as the cursor. This avoids a separate COUNT query for pagination state.
+ *
+ * Comments are ordered newest-first so the most recent appear at the top.
+ * Soft-deleted comments (deletedAt != null) are excluded.
+ */
+export async function getCommentsService(
+  memoryId: string,
+  limit: number,
+  cursor?: string
+): Promise<GetCommentsResult> {
+  // @ts-expect-error — MemoryComment not yet in generated types; resolves after prisma generate
+  const rows = await prisma.memoryComment.findMany({
+    where: { memoryId, deletedAt: null },
+    orderBy: { createdAt: 'desc' },
+    take: limit + 1,
+    ...(cursor
+      ? {
+          cursor: { id: cursor },
+          skip: 1, // skip the cursor row itself
+        }
+      : {}),
+    select: {
+      id: true,
+      content: true,
+      memoryId: true,
+      authorId: true,
+      author: { select: AUTHOR_SELECT },
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const hasMore = rows.length > limit;
+  const items: Comment[] = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore ? (items[items.length - 1]?.id ?? null) : null;
+
+  return { items, nextCursor, hasMore };
+}


### PR DESCRIPTION
## Summary

  Connects the memory uploader's name to the author display in `MemoryDetailModal`, replacing the hardcoded `'Memory Author'` placeholder with real data from the database.

  - **API routes** `get-all-with-coordinates` and `get-by-location` — added `creator: { select: { firstName, lastName } }` to the Prisma `include`. The `Memory → User` relation already existed in the schema; it just wasn't being queried.
  - **`MemoryWithRelations` interface** in `schemas.ts` — added `creator?: { firstName: string; lastName: string } | null`. Nullable to handle memories where `creatorId` is `null` (Prisma uses `onDelete: SetNull`).
  - **`MemoryDetailModal`** — `authorName` now derived from `memory.creator?.firstName + lastName`, falling back to `'Unknown Author'`. `authorInitial` follows from the first character of the resolved name. Applied across all 3 author display sites in the component (base right page, animated left overlay, animated right overlay).

  ### What's intentionally deferred

  - Avatar image (still uses `AvatarFallback` with the initial — no `avatarURL` field on User yet)
  - Author profile linking (name is display-only, not clickable)

  ### Relation to prior work

  The modal was built with a hardcoded author as a UI placeholder since the data pipeline never included creator data. This wires the existing DB relationship end-to-end without touching the modal's animation logic or layout.