### PR TITLE
Scrum 67 connect data on onboarding to profile

### DIFF
--- a/src/app/api/prisma/user/get-current/route.ts
+++ b/src/app/api/prisma/user/get-current/route.ts
@@ -1,0 +1,40 @@
+import { prisma } from '@/lib/prisma';
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+
+/**
+ * GET /api/prisma/user/get-current
+ *
+ * Returns the Prisma User record for the currently authenticated user,
+ * including their program and batch via programBatch relation.
+ * Returns { success: true, data: null } if the user has not yet onboarded.
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+
+    if (!authUser) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    const dbUser = await prisma.user.findUnique({
+      where: { id: authUser.id },
+      include: {
+        programBatch: {
+          include: {
+            program: true,
+            batch: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({ success: true, data: dbUser });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ success: false, message }, { status: 500 });
+  }
+}

--- a/src/app/protected/profile/page.tsx
+++ b/src/app/protected/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useUserAuth } from '@/lib/hooks/useUserAuth';
+import { useCurrentUser } from '@/lib/hooks/useCurrentUser';
 import { ProfileHero } from '@/components/profile/ProfileHero';
 import { ProfileBioCard } from '@/components/profile/ProfileBioCard';
 import { ProfileContactCard } from '@/components/profile/ProfileContactCard';
@@ -10,8 +11,9 @@ import { ProfileSettingsCard } from '@/components/profile/ProfileSettingsCard';
 
 export default function ProfilePage() {
   const { user, loading } = useUserAuth();
+  const { data: currentUserData, isLoading: dbUserLoading } = useCurrentUser();
 
-  if (loading) {
+  if (loading || dbUserLoading) {
     return (
       <div className="flex w-full flex-1 flex-col gap-6">
         <div className="h-32 animate-pulse rounded-xl bg-muted" />
@@ -24,13 +26,20 @@ export default function ProfilePage() {
     );
   }
 
+  const dbUser = currentUserData?.data ?? null;
+
   return (
     <div className="flex w-full flex-1 flex-col gap-6">
-      <ProfileHero user={user} />
+      <ProfileHero user={user} dbUser={dbUser} />
       <div className="grid gap-6 md:grid-cols-2">
         <ProfileBioCard />
         <ProfileContactCard />
-        <ProfileAcademicCard />
+        <ProfileAcademicCard
+          studentId={dbUser?.studentId}
+          program={dbUser?.programBatch.program.name}
+          batch={dbUser?.programBatch.batch.year}
+          status={dbUser?.status}
+        />
         <ProfileActivityCard />
         <ProfileSettingsCard />
       </div>

--- a/src/components/profile/ProfileAcademicCard.tsx
+++ b/src/components/profile/ProfileAcademicCard.tsx
@@ -2,14 +2,30 @@
 
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 
-const academicRows = [
-  { label: 'Student ID', value: '—' },
-  { label: 'Program', value: '—' },
-  { label: 'Batch', value: '—' },
-  { label: 'Status', value: 'Student' },
-];
+interface ProfileAcademicCardProps {
+  studentId?: string | null;
+  program?: string | null;
+  batch?: number | null;
+  status?: 'STUDENT' | 'ALUMNI' | null;
+}
 
-export function ProfileAcademicCard() {
+export function ProfileAcademicCard({
+  studentId,
+  program,
+  batch,
+  status,
+}: ProfileAcademicCardProps) {
+  const rows = [
+    { label: 'Student ID', value: studentId ?? '—' },
+    { label: 'Program', value: program ?? '—' },
+    { label: 'Batch', value: batch != null ? String(batch) : '—' },
+    {
+      label: 'Status',
+      value:
+        status === 'ALUMNI' ? 'Alumni' : status === 'STUDENT' ? 'Student' : '—',
+    },
+  ];
+
   return (
     <Card>
       <CardHeader>
@@ -17,7 +33,7 @@ export function ProfileAcademicCard() {
       </CardHeader>
       <CardContent>
         <ul className="space-y-3">
-          {academicRows.map(({ label, value }) => (
+          {rows.map(({ label, value }) => (
             <li key={label} className="flex items-center justify-between gap-4">
               <span className="text-sm font-medium text-foreground/70">
                 {label}

--- a/src/components/profile/ProfileHero.tsx
+++ b/src/components/profile/ProfileHero.tsx
@@ -4,19 +4,22 @@ import type { User } from '@supabase/supabase-js';
 import Image from 'next/image';
 import { User as UserIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import type { CurrentUserProfile } from '@/lib/hooks/useCurrentUser';
 
 interface ProfileHeroProps {
   user: User | null;
+  dbUser?: CurrentUserProfile | null;
 }
 
-export function ProfileHero({ user }: ProfileHeroProps) {
+export function ProfileHero({ user, dbUser }: ProfileHeroProps) {
   const avatarUrl =
     user?.user_metadata?.avatar_url || user?.user_metadata?.picture;
-  const displayName =
-    user?.user_metadata?.full_name ||
-    user?.user_metadata?.name ||
-    user?.email ||
-    'Unknown User';
+  const displayName = dbUser
+    ? `${dbUser.firstName} ${dbUser.lastName}`
+    : user?.user_metadata?.full_name ||
+      user?.user_metadata?.name ||
+      user?.email ||
+      'Unknown User';
   const email = user?.email;
 
   return (
@@ -39,7 +42,12 @@ export function ProfileHero({ user }: ProfileHeroProps) {
       <div className="flex flex-1 flex-col gap-1 sm:gap-2">
         <h1 className="text-2xl font-bold text-foreground">{displayName}</h1>
         {email && <p className="text-sm text-muted-foreground">{email}</p>}
-        <p className="text-xs text-muted-foreground">Student · Batch 2024</p>
+        {dbUser && (
+          <p className="text-xs text-muted-foreground">
+            {dbUser.status === 'ALUMNI' ? 'Alumni' : 'Student'} · Batch{' '}
+            {dbUser.programBatch.batch.year}
+          </p>
+        )}
       </div>
       <div className="shrink-0">
         <Button

--- a/src/lib/hooks/useCurrentUser.ts
+++ b/src/lib/hooks/useCurrentUser.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export interface CurrentUserProfile {
+  id: string;
+  email: string;
+  studentId: string;
+  firstName: string;
+  lastName: string;
+  status: 'STUDENT' | 'ALUMNI';
+  role: 'USER' | 'ADMIN';
+  programBatch: {
+    id: string;
+    program: { id: string; name: string };
+    batch: { id: string; year: number };
+  };
+}
+
+interface CurrentUserResponse {
+  success: boolean;
+  data: CurrentUserProfile | null;
+}
+
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: ['currentUser'],
+    queryFn: async () => {
+      const res = await fetch('/api/prisma/user/get-current');
+      if (!res.ok) throw new Error('Failed to fetch current user');
+      return res.json() as Promise<CurrentUserResponse>;
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}


### PR DESCRIPTION
  ## Summary

Connects the data collected during onboarding to the profile page. Previously, `ProfileHero` showed a hardcoded `"Student · Batch 2024"` and `ProfileAcademicCard` showed `"—"` for all fields — despite the data already existing in the database from the onboarding flow. This PR adds the necessary connections to fetch it back and display it.

  **API:**

  - **`GET /api/prisma/user/get-current`** — authenticates via Supabase, queries the `User` record by auth ID with `programBatch → program + batch` included. Returns `{ success, data: null }` (not 404) when the user hasn't completed onboarding, so the profile page degrades gracefully rather than erroring.

  **Hook:**

  - **`useCurrentUser`** — `useQuery` keyed on `['currentUser']` with `staleTime: 5min`, `retry: 1`. Exports `CurrentUserProfile` interface with the nested `programBatch.program` and `programBatch.batch` shape. Mirrors the `useLocations` pattern.

  **Profile components:**

  - **`ProfileHero`** — accepts optional `dbUser` prop. Display name now prefers `firstName + lastName` from the DB, falling back to Supabase metadata. Hardcoded `"Student · Batch 2024"` replaced with the real status and batch year; hidden entirely if `dbUser` is null (unonboarded user).
  - **`ProfileAcademicCard`** — accepts `studentId`, `program`, `batch`, `status` props. Rows now built dynamically from props with `"—"` fallback for each field. Formats `STUDENT`/`ALUMNI` enum values as `"Student"`/`"Alumni"`.
  - **Profile page** — calls `useCurrentUser`, extends the loading gate to wait for both auth and DB data, then passes `dbUser` down to both components.

  ### What's intentionally deferred

  - Bio, contact, and activity cards — no corresponding fields exist in the User schema yet.
  - Edit Profile button — remains disabled pending a separate edit flow ticket.
  - Error state on the profile page if the DB fetch fails — currently degrades to `dbUser = null` (same as unonboarded).

  ### Relation to prior work

  Builds directly on the onboarding flow from the existing `user/create` route — no schema changes needed, all fields (`firstName`, `lastName`, `studentId`, `status`, `programBatchId`) were already being saved. Follows the same patterns: `{ success, data }` response envelope, `useQuery` hooks with typed responses, and optional-chaining at the call site for nullable DB relations.