### PR TITLE
Scrum 68 memory transition from gallery to map

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,6 +182,7 @@ model PrivateGroup {
   id          String       @id @default(uuid()) @db.Uuid
   name        String       @unique @db.VarChar(50)
   description String?
+  message     String?      @db.VarChar(300)
   creatorId   String?      @db.Uuid
   deletedAt   DateTime?
   createdAt   DateTime     @default(now())

--- a/src/app/api/prisma/group/[groupId]/route.ts
+++ b/src/app/api/prisma/group/[groupId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { prisma } from '@/lib/prisma';
+import { updateGroupServerSchema } from '@/lib/schemas';
 
 /**
  * GET /api/prisma/group/[groupId]
@@ -58,6 +59,103 @@ export async function GET(
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     console.error('[group/get] Error:', message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/prisma/group/[groupId]
+ *
+ * Updates a group's name, description, or message. Only the group creator
+ * (owner) is allowed to perform this action.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupId: string }> }
+) {
+  try {
+    const { groupId } = await params;
+
+    // ── 1. Authenticate ──────────────────────────────────────────────
+    const supabase = await createClient();
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+
+    if (!authUser) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    // ── 2. Fetch group & verify ownership ────────────────────────────
+    const group = await prisma.privateGroup.findUnique({
+      where: { id: groupId, deletedAt: null },
+      select: { creatorId: true, name: true },
+    });
+
+    if (!group) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+
+    if (group.creatorId !== authUser.id) {
+      return NextResponse.json(
+        { error: 'Only the group owner can update settings' },
+        { status: 403 }
+      );
+    }
+
+    // ── 3. Validate body ─────────────────────────────────────────────
+    const body = await request.json();
+    const parsed = updateGroupServerSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.errors[0]?.message ?? 'Invalid input' },
+        { status: 400 }
+      );
+    }
+
+    const { name, description, message } = parsed.data;
+
+    // ── 4. Check name uniqueness if changing ─────────────────────────
+    if (name && name !== group.name) {
+      const existing = await prisma.privateGroup.findFirst({
+        where: { name, deletedAt: null, id: { not: groupId } },
+      });
+      if (existing) {
+        return NextResponse.json(
+          { error: 'A group with that name already exists' },
+          { status: 409 }
+        );
+      }
+    }
+
+    // ── 5. Update ────────────────────────────────────────────────────
+    const updated = await prisma.privateGroup.update({
+      where: { id: groupId },
+      data: {
+        ...(name !== undefined && { name }),
+        ...(description !== undefined && { description }),
+        ...(message !== undefined && { message }),
+      },
+      include: {
+        creator: {
+          select: { id: true, firstName: true, lastName: true, email: true },
+        },
+        members: {
+          select: { id: true, firstName: true, lastName: true, email: true },
+        },
+        _count: { select: { members: true, memories: true } },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Group updated successfully',
+      data: updated,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[group/patch] Error:', message);
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/prisma/group/[groupId]/route.ts
+++ b/src/app/api/prisma/group/[groupId]/route.ts
@@ -109,7 +109,7 @@ export async function PATCH(
 
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.errors[0]?.message ?? 'Invalid input' },
+        { error: parsed.error.issues[0]?.message ?? 'Invalid input' },
         { status: 400 }
       );
     }

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -68,7 +68,8 @@ function GalleryPageContent() {
   const currentEraStyle = ERA_STYLES[activeEra] || ERA_STYLES[2020];
 
   const handleMemoryClick = (memoryId: string) => {
-    router.push(`/map?memoryId=${memoryId}&era=${activeEra}`);
+    sessionStorage.setItem('gallery_selected_memory', memoryId);
+    router.push('/map');
   };
 
   // Wheel-to-horizontal scroll handler

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -68,8 +68,9 @@ function GalleryPageContent() {
   const currentEraStyle = ERA_STYLES[activeEra] || ERA_STYLES[2020];
 
   const handleMemoryClick = (memoryId: string) => {
-    sessionStorage.setItem('gallery_selected_memory', memoryId);
-    router.push('/map');
+    router.push(
+      `/map?memoryId=${encodeURIComponent(memoryId)}&era=${activeEra}`
+    );
   };
 
   // Wheel-to-horizontal scroll handler

--- a/src/components/gallery/GalleryMemoryCard.tsx
+++ b/src/components/gallery/GalleryMemoryCard.tsx
@@ -14,14 +14,25 @@ export function GalleryMemoryCard({ memory, onClick }: GalleryMemoryCardProps) {
     ? [{ src: memory.mediaURL, alt: memory.title }]
     : [];
 
-  if (photos.length === 0) {
-    return null;
-  }
-
   return (
     <div className="flex shrink-0 items-center gap-8">
       {/* Photo cluster (left side) */}
-      <PolaroidCluster photos={photos} onPhotoClick={onClick} />
+      {photos.length > 0 ? (
+        <PolaroidCluster photos={photos} onPhotoClick={onClick} />
+      ) : (
+        <button
+          type="button"
+          onClick={onClick}
+          className="border-2 border-border bg-card p-2 pb-12 shadow-[4px_4px_0px_0px_#2d2d2d] transition-transform hover:scale-[1.02]"
+          aria-label={`Open notebook for ${memory.title}`}
+        >
+          <div className="flex h-[324px] w-[290px] items-center justify-center bg-secondary">
+            <span className="font-dancing text-3xl italic text-muted-foreground">
+              No Photo Yet
+            </span>
+          </div>
+        </button>
+      )}
 
       {/* Caption (right side) */}
       <div className="w-72 shrink-0">

--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -11,6 +11,7 @@ import { DeleteGroupModal } from '@/components/groups/DeleteGroupModal';
 import { MembersTab } from '@/components/groups/tabs/MembersTab';
 import { MediaTab } from '@/components/groups/tabs/MediaTab';
 import { AboutTab } from '@/components/groups/tabs/AboutTab';
+import { SettingsTab } from '@/components/groups/tabs/SettingsTab';
 import { type Group, type GroupMember } from '@/lib/types/group';
 import { useUserAuth } from '@/lib/hooks/useUserAuth';
 import {
@@ -28,6 +29,7 @@ import {
   Users,
   Image as ImageIcon,
   Info,
+  Settings,
   UserPlus,
   Share2,
   Trash2,
@@ -51,7 +53,7 @@ interface GroupPanelProps {
   onOpenChange: (open: boolean) => void;
 }
 
-type TabType = 'members' | 'media' | 'about';
+type TabType = 'members' | 'media' | 'settings' | 'about';
 
 /** Transform an API member response to the frontend GroupMember shape. */
 function toGroupMember(
@@ -73,6 +75,7 @@ function toGroup(g: GroupResponse): Group {
     id: g.id,
     name: g.name,
     description: g.description ?? undefined,
+    message: g.message ?? undefined,
     privacy: 'PRIVATE',
     visibility: 'VISIBLE',
     coverPhotoUrl: undefined,
@@ -254,6 +257,21 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
                     <span>Media</span>
                   </button>
 
+                  {isOwner && (
+                    <button
+                      onClick={() => setActiveTab('settings')}
+                      className={cn(
+                        'flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-sm font-medium transition-colors',
+                        activeTab === 'settings'
+                          ? 'bg-secondary text-foreground'
+                          : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+                      )}
+                    >
+                      <Settings className="h-4 w-4" />
+                      <span>Settings</span>
+                    </button>
+                  )}
+
                   <button
                     onClick={() => setActiveTab('about')}
                     className={cn(
@@ -381,6 +399,12 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
                     />
                   )}
                   {activeTab === 'media' && <MediaTab group={selectedGroup} />}
+                  {activeTab === 'settings' && isOwner && (
+                    <SettingsTab
+                      group={selectedGroup}
+                      onUpdated={() => refetchGroupDetail()}
+                    />
+                  )}
                   {activeTab === 'about' && <AboutTab group={selectedGroup} />}
                 </div>
               </>

--- a/src/components/groups/tabs/AboutTab.tsx
+++ b/src/components/groups/tabs/AboutTab.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { Globe, Lock, Eye, EyeOff, Users, Calendar, Crown } from 'lucide-react';
+import {
+  Globe,
+  Lock,
+  Eye,
+  EyeOff,
+  Users,
+  Calendar,
+  Crown,
+  MessageSquare,
+} from 'lucide-react';
 import { type Group } from '@/lib/types/group';
 
 function formatFullDate(dateStr: string): string {
@@ -33,6 +42,26 @@ export function AboutTab({ group }: AboutTabProps) {
           <p className="text-sm italic text-gray-400">
             No description provided.
           </p>
+        )}
+      </div>
+
+      {/* Group Message */}
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-gray-400">
+          Group Message
+        </h3>
+        {group.message ? (
+          <div className="flex items-start gap-2.5 rounded border border-border/50 bg-postit/30 px-3 py-2.5">
+            <MessageSquare
+              size={15}
+              className="mt-0.5 shrink-0 text-gray-400"
+            />
+            <p className="text-sm leading-relaxed text-gray-700">
+              {group.message}
+            </p>
+          </div>
+        ) : (
+          <p className="text-sm italic text-gray-400">No message set.</p>
         )}
       </div>
 

--- a/src/components/groups/tabs/MediaTab.tsx
+++ b/src/components/groups/tabs/MediaTab.tsx
@@ -48,7 +48,7 @@ export function MediaTab({ group }: MediaTabProps) {
   const hasMemories = memories && memories.length > 0;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 px-5 py-4">
       {/* Header with post count and add button */}
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold">

--- a/src/components/groups/tabs/SettingsTab.tsx
+++ b/src/components/groups/tabs/SettingsTab.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { useState } from 'react';
+import { Pencil, Check, X, Loader2, Settings } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { type Group } from '@/lib/types/group';
+import { useUpdateGroup } from '@/lib/hooks/useUpdateGroup';
+import { WOBBLY_RADIUS } from '@/lib/hand-drawn';
+import { cn } from '@/lib/utils';
+
+interface SettingsTabProps {
+  group: Group;
+  onUpdated: () => void;
+}
+
+type EditingField = 'name' | 'description' | 'message' | null;
+
+export function SettingsTab({ group, onUpdated }: SettingsTabProps) {
+  const [editingField, setEditingField] = useState<EditingField>(null);
+  const [draft, setDraft] = useState('');
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const updateGroup = useUpdateGroup();
+
+  const startEditing = (field: EditingField) => {
+    if (!field) return;
+    setEditingField(field);
+    setFieldError(null);
+
+    if (field === 'name') setDraft(group.name);
+    else if (field === 'description') setDraft(group.description ?? '');
+    else if (field === 'message') setDraft(group.message ?? '');
+  };
+
+  const cancelEditing = () => {
+    setEditingField(null);
+    setDraft('');
+    setFieldError(null);
+  };
+
+  const saveField = () => {
+    if (!editingField) return;
+
+    const trimmed = draft.trim();
+
+    // Validate
+    if (editingField === 'name' && trimmed.length === 0) {
+      setFieldError('Group name cannot be empty');
+      return;
+    }
+    if (editingField === 'name' && trimmed.length > 50) {
+      setFieldError('Group name must be 50 characters or less');
+      return;
+    }
+    if (editingField === 'description' && trimmed.length > 500) {
+      setFieldError('Description must be 500 characters or less');
+      return;
+    }
+    if (editingField === 'message' && trimmed.length > 300) {
+      setFieldError('Message must be 300 characters or less');
+      return;
+    }
+
+    // Build payload — send empty string as empty, let backend handle nullable
+    const payload: Record<string, string> = {};
+    if (editingField === 'name') payload.name = trimmed;
+    else if (editingField === 'description') payload.description = trimmed;
+    else if (editingField === 'message') payload.message = trimmed;
+
+    updateGroup.mutate(
+      { groupId: group.id, data: payload },
+      {
+        onSuccess: () => {
+          setEditingField(null);
+          setDraft('');
+          setFieldError(null);
+          onUpdated();
+        },
+        onError: (err) => {
+          setFieldError(err.message);
+        },
+      }
+    );
+  };
+
+  const isSaving = updateGroup.isPending;
+
+  return (
+    <div className="flex flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-border px-5 py-3">
+        <Settings className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-semibold text-foreground">Settings</span>
+      </div>
+
+      <div className="space-y-6 px-5 py-4">
+        {/* Group Name */}
+        <FieldRow
+          label="Group Name"
+          value={group.name}
+          placeholder="Enter group name"
+          isEditing={editingField === 'name'}
+          draft={draft}
+          error={editingField === 'name' ? fieldError : null}
+          isSaving={isSaving}
+          maxLength={50}
+          onEdit={() => startEditing('name')}
+          onDraftChange={setDraft}
+          onSave={saveField}
+          onCancel={cancelEditing}
+        />
+
+        {/* Group Description */}
+        <FieldRow
+          label="Group Description"
+          value={group.description ?? ''}
+          emptyText="No description provided"
+          placeholder="Enter group description"
+          isEditing={editingField === 'description'}
+          draft={draft}
+          error={editingField === 'description' ? fieldError : null}
+          isSaving={isSaving}
+          maxLength={500}
+          multiline
+          onEdit={() => startEditing('description')}
+          onDraftChange={setDraft}
+          onSave={saveField}
+          onCancel={cancelEditing}
+        />
+
+        {/* Group Message */}
+        <FieldRow
+          label="Group Message"
+          value={group.message ?? ''}
+          emptyText="No message set"
+          placeholder="Enter a message for your group members"
+          isEditing={editingField === 'message'}
+          draft={draft}
+          error={editingField === 'message' ? fieldError : null}
+          isSaving={isSaving}
+          maxLength={300}
+          multiline
+          onEdit={() => startEditing('message')}
+          onDraftChange={setDraft}
+          onSave={saveField}
+          onCancel={cancelEditing}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ─── Inline Editable Field ───────────────────────────────────────── */
+
+interface FieldRowProps {
+  label: string;
+  value: string;
+  emptyText?: string;
+  placeholder?: string;
+  isEditing: boolean;
+  draft: string;
+  error: string | null;
+  isSaving: boolean;
+  maxLength: number;
+  multiline?: boolean;
+  onEdit: () => void;
+  onDraftChange: (v: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+function FieldRow({
+  label,
+  value,
+  emptyText = 'Not set',
+  placeholder,
+  isEditing,
+  draft,
+  error,
+  isSaving,
+  maxLength,
+  multiline,
+  onEdit,
+  onDraftChange,
+  onSave,
+  onCancel,
+}: FieldRowProps) {
+  return (
+    <div className="space-y-1.5">
+      {/* Label + pencil */}
+      <div className="flex items-center gap-2">
+        <span className="font-hand text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          {label}
+        </span>
+        {!isEditing && (
+          <button
+            onClick={onEdit}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            aria-label={`Edit ${label}`}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {isEditing ? (
+        <div className="space-y-2">
+          {multiline ? (
+            <textarea
+              value={draft}
+              onChange={(e) => onDraftChange(e.target.value)}
+              placeholder={placeholder}
+              maxLength={maxLength}
+              rows={3}
+              disabled={isSaving}
+              className={cn(
+                'w-full resize-none border-2 border-border bg-card px-3 py-2 font-hand text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring',
+                error && 'border-destructive'
+              )}
+              style={{ borderRadius: WOBBLY_RADIUS }}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') onCancel();
+              }}
+            />
+          ) : (
+            <Input
+              value={draft}
+              onChange={(e) => onDraftChange(e.target.value)}
+              placeholder={placeholder}
+              maxLength={maxLength}
+              disabled={isSaving}
+              className={cn(
+                'border-2 font-hand text-sm',
+                error && 'border-destructive'
+              )}
+              style={{ borderRadius: WOBBLY_RADIUS }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') onSave();
+                if (e.key === 'Escape') onCancel();
+              }}
+            />
+          )}
+
+          {/* Counter + error */}
+          <div className="flex items-center justify-between">
+            <span className="font-hand text-xs text-muted-foreground">
+              {draft.length}/{maxLength}
+            </span>
+            {error && (
+              <span className="font-hand text-xs text-destructive">
+                {error}
+              </span>
+            )}
+          </div>
+
+          {/* Save / Cancel */}
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              onClick={onSave}
+              disabled={isSaving}
+              className="gap-1.5 font-hand"
+              style={{ borderRadius: WOBBLY_RADIUS }}
+            >
+              {isSaving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Check className="h-3.5 w-3.5" />
+              )}
+              Save
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onCancel}
+              disabled={isSaving}
+              className="gap-1.5 font-hand"
+              style={{ borderRadius: WOBBLY_RADIUS }}
+            >
+              <X className="h-3.5 w-3.5" />
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <p
+          className={cn(
+            'font-hand text-sm leading-relaxed',
+            value ? 'text-foreground' : 'italic text-muted-foreground'
+          )}
+        >
+          {value || emptyText}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -550,9 +550,8 @@ export function MapComponent() {
     }
   }, [isClient, handleLandmarkClick, mapError]);
 
-  // Handle memoryId URL param (for gallery → map navigation)
+  // Handle gallery → map navigation via sessionStorage
   useEffect(() => {
-    // Only process once per page load to avoid re-entry on state changes
     if (galleryNavProcessedRef.current) return;
     if (
       !mapRef.current ||
@@ -562,21 +561,16 @@ export function MapComponent() {
     )
       return;
 
-    const params = new URLSearchParams(window.location.search);
-    const memoryIdParam = params.get('memoryId');
+    const memoryId = sessionStorage.getItem('gallery_selected_memory');
+    if (!memoryId) return;
 
-    if (!memoryIdParam) return;
-
-    // Mark as processed immediately so re-renders don't re-trigger this
+    // Consume immediately so it doesn't re-trigger
     galleryNavProcessedRef.current = true;
+    sessionStorage.removeItem('gallery_selected_memory');
 
-    // Clear URL params right away (we've captured what we need)
-    window.history.replaceState({}, '', window.location.pathname);
-
-    // Find the memory by ID
-    const targetMemory = memories.find((m) => m.id === memoryIdParam);
+    const targetMemory = memories.find((m) => m.id === memoryId);
     if (!targetMemory) {
-      console.warn(`Memory with ID ${memoryIdParam} not found`);
+      console.warn(`Memory with ID ${memoryId} not found`);
       return;
     }
 
@@ -595,14 +589,12 @@ export function MapComponent() {
     };
 
     if (needsEraSwitch) {
-      // Switch era and wait for the new style to load before flying
       const onStyleLoad = () => {
         map.off('style.load', onStyleLoad);
         setTimeout(openMemoryDetail, 300);
       };
       map.on('style.load', onStyleLoad);
       setActiveMapEra(memoryEra);
-      // Note: the activeMapEra useEffect (line ~612) will call setStyle
     } else {
       setTimeout(openMemoryDetail, 300);
     }

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -16,6 +16,7 @@ import { Plus, Filter } from 'lucide-react';
 import { AddMemoryModal } from './add-memory-modal';
 import {
   FilterMemoriesModal,
+  DEFAULT_FILTERS,
   type MemoryFilters,
 } from './map/FilterMemoriesModal';
 import { GroupPanel } from './groups/GroupPanel';
@@ -159,6 +160,9 @@ export function MapComponent() {
 
   // Read era URL parameter on mount (for homepage → map navigation)
   useEffect(() => {
+    // Always start with clean filters on fresh map entry.
+    setFilters(DEFAULT_FILTERS);
+
     const params = new URLSearchParams(window.location.search);
     const eraParam = params.get('era');
 

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -113,6 +113,7 @@ export function MapComponent() {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const processedMemoryParamRef = useRef<string | null>(null);
+  const cameraFocusedMemoryParamRef = useRef<string | null>(null);
   const [mapError, setMapError] = useState<string | null>(null);
   const [mapReady, setMapReady] = useState(false);
   const [isClient, setIsClient] = useState(false);
@@ -553,15 +554,9 @@ export function MapComponent() {
     }
   }, [isClient, handleLandmarkClick, mapError]);
 
-  // Handle memoryId URL param (for gallery → map navigation)
+  // Phase 1: open notebook immediately when a memoryId is present
   useEffect(() => {
-    if (
-      !mapRef.current ||
-      !mapReady ||
-      memoriesLoading ||
-      memories.length === 0
-    )
-      return;
+    if (memoriesLoading || memories.length === 0) return;
 
     const params = new URLSearchParams(window.location.search);
     const memoryIdParam = params.get('memoryId');
@@ -578,12 +573,39 @@ export function MapComponent() {
     }
 
     processedMemoryParamRef.current = memoryIdParam;
+    setSelectedMemory(targetMemory);
+    setMemoryDetailOpen(true);
+  }, [memories, memoriesLoading]);
 
-    // Switch era if needed
+  // Phase 2: once map is ready, align era and camera for the selected memory
+  useEffect(() => {
+    if (
+      !mapRef.current ||
+      !mapReady ||
+      memoriesLoading ||
+      memories.length === 0
+    )
+      return;
+
+    const params = new URLSearchParams(window.location.search);
+    const memoryIdParam = params.get('memoryId');
+
+    if (!memoryIdParam) return;
+    if (cameraFocusedMemoryParamRef.current === memoryIdParam) return;
+
+    const targetMemory = memories.find((m) => m.id === memoryIdParam);
+    if (!targetMemory) {
+      cameraFocusedMemoryParamRef.current = memoryIdParam;
+      return;
+    }
+
+    cameraFocusedMemoryParamRef.current = memoryIdParam;
+
     const memoryEra = getEraFromBatchTag(
       targetMemory.tags ?? [],
       targetMemory.createdAt
     );
+
     if (memoryEra !== activeMapEra) {
       const map = mapRef.current;
       if (!map) return;
@@ -591,10 +613,7 @@ export function MapComponent() {
       const onStyleLoad = () => {
         map.off('style.load', onStyleLoad);
         setTimeout(() => {
-          flyToMemoryWithSequence(targetMemory, () => {
-            setSelectedMemory(targetMemory);
-            setMemoryDetailOpen(true);
-          });
+          flyToMemoryWithSequence(targetMemory);
         }, 300);
       };
 
@@ -602,10 +621,7 @@ export function MapComponent() {
       setActiveMapEra(memoryEra);
     } else {
       setTimeout(() => {
-        flyToMemoryWithSequence(targetMemory, () => {
-          setSelectedMemory(targetMemory);
-          setMemoryDetailOpen(true);
-        });
+        flyToMemoryWithSequence(targetMemory);
       }, 300);
     }
   }, [

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -108,6 +108,9 @@ const CAMERA_ANIMATION = {
   essential: true, // Ensures animation is not skipped even if user prefers reduced motion
 };
 
+const DEFAULT_MAP_CENTER: [number, number] = [123.8986, 10.3224];
+const DEFAULT_MAP_ZOOM = 17;
+
 export function MapComponent() {
   const router = useRouter();
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
@@ -287,9 +290,19 @@ export function MapComponent() {
   }, []);
 
   const closeNotebookView = useCallback(() => {
+    const map = mapRef.current;
+
     setMemoryDetailOpen(false);
     setSelectedMemory(null);
     setSelectedLandmark(null);
+
+    // Return to the default overview camera after leaving notebook mode.
+    map?.easeTo({
+      center: DEFAULT_MAP_CENTER,
+      zoom: DEFAULT_MAP_ZOOM,
+      duration: 900,
+      essential: true,
+    });
 
     const params = new URLSearchParams(window.location.search);
     params.delete('memoryId');
@@ -507,8 +520,8 @@ export function MapComponent() {
         const map = new mapboxgl.Map({
           container: mapContainerRef.current,
           style: 'mapbox://styles/mapbox/streets-v12',
-          center: [123.8986, 10.3224],
-          zoom: 17,
+          center: DEFAULT_MAP_CENTER,
+          zoom: DEFAULT_MAP_ZOOM,
           minZoom: 16,
           maxZoom: 22,
           maxBounds: [

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -286,6 +286,39 @@ export function MapComponent() {
     handleMemoryClickRef.current(memory);
   }, []);
 
+  const closeNotebookView = useCallback(() => {
+    setMemoryDetailOpen(false);
+    setSelectedMemory(null);
+    setSelectedLandmark(null);
+
+    const params = new URLSearchParams(window.location.search);
+    params.delete('memoryId');
+    params.set('era', String(activeMapEra));
+
+    processedMemoryParamRef.current = null;
+    cameraFocusedMemoryParamRef.current = null;
+
+    const nextUrl = `/map?${params.toString()}`;
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+    if (currentUrl !== nextUrl) {
+      router.replace(nextUrl, { scroll: false });
+    }
+  }, [activeMapEra, router]);
+
+  // Force Escape behavior for notebook mode: close and return to era map URL.
+  useEffect(() => {
+    if (!memoryDetailOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      closeNotebookView();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [memoryDetailOpen, closeNotebookView]);
+
   // ---------------------------------------------------------------------------
   // Batches → FlyTo → Detail handler
   // ---------------------------------------------------------------------------
@@ -642,6 +675,50 @@ export function MapComponent() {
     mapRef.current.setStyle(targetStyle);
   }, [activeMapEra]);
 
+  // Keep URL in sync with notebook state so each opened memory has a stable deep link.
+  useEffect(() => {
+    if (!isClient) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const currentMemoryIdParam = params.get('memoryId');
+
+    // If a memoryId came from an external navigation (e.g., gallery click),
+    // preserve it only until initial notebook selection is established.
+    const hasPendingIncomingMemoryId =
+      !selectedMemory &&
+      !!currentMemoryIdParam &&
+      processedMemoryParamRef.current !== currentMemoryIdParam;
+
+    // Preserve active era in URL for consistency when sharing/reloading.
+    params.set('era', String(activeMapEra));
+
+    if (memoryDetailOpen && selectedMemory?.id) {
+      params.set('memoryId', selectedMemory.id);
+    } else if (!hasPendingIncomingMemoryId) {
+      params.delete('memoryId');
+
+      // Reset processed refs when leaving notebook mode so reopening via URL works
+      // for the same memory ID in a later navigation.
+      processedMemoryParamRef.current = null;
+      cameraFocusedMemoryParamRef.current = null;
+    }
+
+    const nextSearch = params.toString();
+    const nextUrl = nextSearch ? `/map?${nextSearch}` : '/map';
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+
+    if (currentUrl !== nextUrl) {
+      router.replace(nextUrl, { scroll: false });
+    }
+  }, [
+    isClient,
+    activeMapEra,
+    memoryDetailOpen,
+    selectedMemory,
+    selectedMemory?.id,
+    router,
+  ]);
+
   // Re-render marker roots when memory counts update or visibility changes
   useEffect(() => {
     for (const { root, landmark } of markerRootsRef.current) {
@@ -950,7 +1027,13 @@ export function MapComponent() {
       <MemoryDetailModal
         memory={selectedMemory}
         open={memoryDetailOpen}
-        onOpenChange={setMemoryDetailOpen}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            closeNotebookView();
+            return;
+          }
+          setMemoryDetailOpen(true);
+        }}
         onMemoryDeleted={() => setSelectedMemory(null)}
         hasPrevious={
           selectedMemory

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -445,27 +445,6 @@ export function MapComponent() {
     };
   }, [locationSelectionMode, handleLocationSelected]);
 
-  const handleRequestMapSelection = useCallback(
-    (
-      mode: 'landmark' | 'custom',
-      onSelect: (selection: MapLocationSelection) => void
-    ) => {
-      locationSelectionCallbackRef.current = onSelect;
-      setLocationSelectionMode(mode);
-      setPendingLocationSelection(null);
-
-      // Show landmarks when selecting landmark, hide memory pins during selection
-      if (mode === 'landmark') {
-        setShowLandmarks(true);
-      }
-      setShowMemoryPins(false);
-
-      // Re-open the modal after selection or cancel
-      setAddMemoryOpen(true);
-    },
-    []
-  );
-
   useLayoutEffect(() => {
     setIsClient(true);
     if (!MAPBOX_TOKEN) {
@@ -908,7 +887,6 @@ export function MapComponent() {
           }
         }}
         defaultEra={addMemoryEra}
-        onRequestMapSelection={handleRequestMapSelection}
       />
 
       {/* Map Location Selector Overlay */}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -151,6 +151,9 @@ export function MapComponent() {
   // Pending memory for the flyTo → open detail flow
   const pendingMemoryRef = useRef<MemoryWithCoordinates | null>(null);
 
+  // Track whether the gallery → map memoryId URL param has been processed
+  const galleryNavProcessedRef = useRef(false);
+
   // Read era URL parameter on mount (for homepage → map navigation)
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -549,13 +552,26 @@ export function MapComponent() {
 
   // Handle memoryId URL param (for gallery → map navigation)
   useEffect(() => {
-    if (!mapRef.current || memoriesLoading || !memories) return;
+    // Only process once per page load to avoid re-entry on state changes
+    if (galleryNavProcessedRef.current) return;
+    if (
+      !mapRef.current ||
+      memoriesLoading ||
+      !memories ||
+      memories.length === 0
+    )
+      return;
 
     const params = new URLSearchParams(window.location.search);
     const memoryIdParam = params.get('memoryId');
-    const eraParam = params.get('era');
 
     if (!memoryIdParam) return;
+
+    // Mark as processed immediately so re-renders don't re-trigger this
+    galleryNavProcessedRef.current = true;
+
+    // Clear URL params right away (we've captured what we need)
+    window.history.replaceState({}, '', window.location.pathname);
 
     // Find the memory by ID
     const targetMemory = memories.find((m) => m.id === memoryIdParam);
@@ -564,49 +580,33 @@ export function MapComponent() {
       return;
     }
 
-    // Switch era if needed
+    const map = mapRef.current;
     const memoryEra = getEraFromBatchTag(
       targetMemory.tags ?? [],
       targetMemory.createdAt
     );
-    if (eraParam && memoryEra !== activeMapEra) {
-      setActiveMapEra(memoryEra);
-      mapRef.current.setStyle(ERA_MAP_STYLES[memoryEra]);
-    }
+    const needsEraSwitch = memoryEra !== activeMapEra;
 
-    // Wait for style to load, then fly to memory and open modal
-    const onStyleLoad = () => {
-      mapRef.current?.off('style.load', onStyleLoad);
-      setTimeout(() => {
-        flyToMemoryWithSequence(targetMemory, () => {
-          setSelectedMemory(targetMemory);
-          setMemoryDetailOpen(true);
-        });
-      }, 300);
+    const openMemoryDetail = () => {
+      flyToMemoryWithSequence(targetMemory, () => {
+        setSelectedMemory(targetMemory);
+        setMemoryDetailOpen(true);
+      });
     };
 
-    if (memoryEra !== activeMapEra) {
-      mapRef.current.on('style.load', onStyleLoad);
+    if (needsEraSwitch) {
+      // Switch era and wait for the new style to load before flying
+      const onStyleLoad = () => {
+        map.off('style.load', onStyleLoad);
+        setTimeout(openMemoryDetail, 300);
+      };
+      map.on('style.load', onStyleLoad);
+      setActiveMapEra(memoryEra);
+      // Note: the activeMapEra useEffect (line ~612) will call setStyle
     } else {
-      setTimeout(() => {
-        flyToMemoryWithSequence(targetMemory, () => {
-          setSelectedMemory(targetMemory);
-          setMemoryDetailOpen(true);
-        });
-      }, 300);
+      setTimeout(openMemoryDetail, 300);
     }
-
-    // Clear URL params after processing (optional - keeps URL clean)
-    window.history.replaceState({}, '', window.location.pathname);
-  }, [
-    memories,
-    memoriesLoading,
-    activeMapEra,
-    flyToMemoryWithSequence,
-    setActiveMapEra,
-    setSelectedMemory,
-    setMemoryDetailOpen,
-  ]);
+  }, [memories, memoriesLoading, activeMapEra, flyToMemoryWithSequence]);
 
   // Switch Mapbox style when the active era changes
   useEffect(() => {

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -112,7 +112,9 @@ export function MapComponent() {
   const router = useRouter();
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
+  const processedMemoryParamRef = useRef<string | null>(null);
   const [mapError, setMapError] = useState<string | null>(null);
+  const [mapReady, setMapReady] = useState(false);
   const [isClient, setIsClient] = useState(false);
   const [addMemoryOpen, setAddMemoryOpen] = useState(false);
   const [addMemoryEra, setAddMemoryEra] = useState<number | null>(null);
@@ -150,9 +152,6 @@ export function MapComponent() {
 
   // Pending memory for the flyTo → open detail flow
   const pendingMemoryRef = useRef<MemoryWithCoordinates | null>(null);
-
-  // Track whether the gallery → map memoryId URL param has been processed
-  const galleryNavProcessedRef = useRef(false);
 
   // Read era URL parameter on mount (for homepage → map navigation)
   useEffect(() => {
@@ -486,6 +485,9 @@ export function MapComponent() {
         });
 
         mapRef.current = map;
+        map.once('load', () => {
+          setMapReady(true);
+        });
 
         map.addControl(new mapboxgl.NavigationControl(), 'top-left');
         map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
@@ -538,6 +540,7 @@ export function MapComponent() {
           memoryRootsRef.current = [];
           map.remove();
           mapRef.current = null;
+          setMapReady(false);
         };
       } catch (error) {
         console.error('Failed to initialize map:', error);
@@ -550,55 +553,71 @@ export function MapComponent() {
     }
   }, [isClient, handleLandmarkClick, mapError]);
 
-  // Handle gallery → map navigation via sessionStorage
+  // Handle memoryId URL param (for gallery → map navigation)
   useEffect(() => {
-    if (galleryNavProcessedRef.current) return;
     if (
       !mapRef.current ||
+      !mapReady ||
       memoriesLoading ||
-      !memories ||
       memories.length === 0
     )
       return;
 
-    const memoryId = sessionStorage.getItem('gallery_selected_memory');
-    if (!memoryId) return;
+    const params = new URLSearchParams(window.location.search);
+    const memoryIdParam = params.get('memoryId');
 
-    // Consume immediately so it doesn't re-trigger
-    galleryNavProcessedRef.current = true;
-    sessionStorage.removeItem('gallery_selected_memory');
+    if (!memoryIdParam) return;
+    if (processedMemoryParamRef.current === memoryIdParam) return;
 
-    const targetMemory = memories.find((m) => m.id === memoryId);
+    // Find the memory by ID
+    const targetMemory = memories.find((m) => m.id === memoryIdParam);
     if (!targetMemory) {
-      console.warn(`Memory with ID ${memoryId} not found`);
+      console.warn(`Memory with ID ${memoryIdParam} not found`);
+      processedMemoryParamRef.current = memoryIdParam;
       return;
     }
 
-    const map = mapRef.current;
+    processedMemoryParamRef.current = memoryIdParam;
+
+    // Switch era if needed
     const memoryEra = getEraFromBatchTag(
       targetMemory.tags ?? [],
       targetMemory.createdAt
     );
-    const needsEraSwitch = memoryEra !== activeMapEra;
+    if (memoryEra !== activeMapEra) {
+      const map = mapRef.current;
+      if (!map) return;
 
-    const openMemoryDetail = () => {
-      flyToMemoryWithSequence(targetMemory, () => {
-        setSelectedMemory(targetMemory);
-        setMemoryDetailOpen(true);
-      });
-    };
-
-    if (needsEraSwitch) {
       const onStyleLoad = () => {
         map.off('style.load', onStyleLoad);
-        setTimeout(openMemoryDetail, 300);
+        setTimeout(() => {
+          flyToMemoryWithSequence(targetMemory, () => {
+            setSelectedMemory(targetMemory);
+            setMemoryDetailOpen(true);
+          });
+        }, 300);
       };
+
       map.on('style.load', onStyleLoad);
       setActiveMapEra(memoryEra);
     } else {
-      setTimeout(openMemoryDetail, 300);
+      setTimeout(() => {
+        flyToMemoryWithSequence(targetMemory, () => {
+          setSelectedMemory(targetMemory);
+          setMemoryDetailOpen(true);
+        });
+      }, 300);
     }
-  }, [memories, memoriesLoading, activeMapEra, flyToMemoryWithSequence]);
+  }, [
+    memories,
+    memoriesLoading,
+    activeMapEra,
+    mapReady,
+    flyToMemoryWithSequence,
+    setActiveMapEra,
+    setSelectedMemory,
+    setMemoryDetailOpen,
+  ]);
 
   // Switch Mapbox style when the active era changes
   useEffect(() => {

--- a/src/lib/hooks/useCreateGroup.ts
+++ b/src/lib/hooks/useCreateGroup.ts
@@ -14,6 +14,7 @@ export interface GroupResponse {
   id: string;
   name: string;
   description: string | null;
+  message: string | null;
   creatorId: string | null;
   creator: GroupMemberResponse | null;
   members: GroupMemberResponse[];

--- a/src/lib/hooks/useGroupById.ts
+++ b/src/lib/hooks/useGroupById.ts
@@ -13,6 +13,7 @@ interface GroupDetailResponse {
   id: string;
   name: string;
   description: string | null;
+  message: string | null;
   creatorId: string | null;
   creator: GroupMemberResponse | null;
   members: GroupMemberResponse[];

--- a/src/lib/hooks/useUpdateGroup.ts
+++ b/src/lib/hooks/useUpdateGroup.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { UpdateGroupServerInput } from '@/lib/schemas';
+
+interface UpdateGroupVariables {
+  groupId: string;
+  data: UpdateGroupServerInput;
+}
+
+export function useUpdateGroup() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ groupId, data }: UpdateGroupVariables) => {
+      const res = await fetch(
+        `/api/prisma/group/${encodeURIComponent(groupId)}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        }
+      );
+
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? 'Failed to update group');
+      return body.data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['groups', variables.groupId],
+      });
+      queryClient.invalidateQueries({ queryKey: ['groups', 'mine'] });
+    },
+  });
+}

--- a/src/lib/hooks/useUserGroups.ts
+++ b/src/lib/hooks/useUserGroups.ts
@@ -13,6 +13,7 @@ interface GroupResponse {
   id: string;
   name: string;
   description: string | null;
+  message: string | null;
   creatorId: string | null;
   creator: GroupMemberResponse | null;
   members: GroupMemberResponse[];

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -265,6 +265,11 @@ export const updateGroupServerSchema = z.object({
     .trim()
     .max(500, 'Description must be 500 characters or less')
     .optional(),
+  message: z
+    .string()
+    .trim()
+    .max(300, 'Message must be 300 characters or less')
+    .optional(),
 });
 
 /** Schema for adding/removing a member by email. */

--- a/src/lib/types/group.ts
+++ b/src/lib/types/group.ts
@@ -25,6 +25,7 @@ export interface Group {
   id: string;
   name: string;
   description?: string | null;
+  message?: string | null;
   privacy: GroupPrivacy;
   visibility: GroupVisibility;
   coverPhotoUrl?: string | null;


### PR DESCRIPTION
- Added stable gallery-to-map deep linking using memoryId + era query params.
- Synced notebook modal state with URL and removed stale memoryId on close/Escape.
- Added explicit notebook close flow to return to era-only map URL.
- Reset map filters on entry to prevent blank map when navigating to an era.

## **POSSIBLE ISSUE: memoryId is visible in URL but can enforce strict server authorization checks**