### PR TITLE
Scrum-68-memory transition from gallery to map

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -68,7 +68,9 @@ function GalleryPageContent() {
   const currentEraStyle = ERA_STYLES[activeEra] || ERA_STYLES[2020];
 
   const handleMemoryClick = (memoryId: string) => {
-    router.push(`/map?memoryId=${memoryId}&era=${activeEra}`);
+    router.push(
+      `/map?memoryId=${encodeURIComponent(memoryId)}&era=${activeEra}`
+    );
   };
 
   // Wheel-to-horizontal scroll handler

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -119,6 +119,7 @@ export function MapComponent() {
   const processedMemoryParamRef = useRef<string | null>(null);
   const cameraFocusedMemoryParamRef = useRef<string | null>(null);
   const [mapError, setMapError] = useState<string | null>(null);
+  const [mapReady, setMapReady] = useState(false);
   const [isClient, setIsClient] = useState(false);
   const [addMemoryOpen, setAddMemoryOpen] = useState(false);
   const [addMemoryEra, setAddMemoryEra] = useState<number | null>(null);
@@ -535,6 +536,9 @@ export function MapComponent() {
         });
 
         mapRef.current = map;
+        map.once('load', () => {
+          setMapReady(true);
+        });
 
         map.addControl(new mapboxgl.NavigationControl(), 'top-left');
         map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
@@ -587,6 +591,7 @@ export function MapComponent() {
           memoryRootsRef.current = [];
           map.remove();
           mapRef.current = null;
+          setMapReady(false);
         };
       } catch (error) {
         console.error('Failed to initialize map:', error);
@@ -599,65 +604,83 @@ export function MapComponent() {
     }
   }, [isClient, handleLandmarkClick, mapError]);
 
-  // Handle memoryId URL param (for gallery → map navigation)
+  // Phase 1: open notebook immediately when a memoryId is present
   useEffect(() => {
-    if (!mapRef.current || memoriesLoading || !memories) return;
+    if (memoriesLoading || memories.length === 0) return;
 
     const params = new URLSearchParams(window.location.search);
     const memoryIdParam = params.get('memoryId');
-    const eraParam = params.get('era');
 
     if (!memoryIdParam) return;
+    if (processedMemoryParamRef.current === memoryIdParam) return;
 
     // Find the memory by ID
     const targetMemory = memories.find((m) => m.id === memoryIdParam);
     if (!targetMemory) {
       console.warn(`Memory with ID ${memoryIdParam} not found`);
+      processedMemoryParamRef.current = memoryIdParam;
       return;
     }
+
+    processedMemoryParamRef.current = memoryIdParam;
+    setSelectedMemory(targetMemory);
+    setMemoryDetailOpen(true);
+  }, [memories, memoriesLoading]);
+
+  // Phase 2: once map is ready, align era and camera for the selected memory
+  useEffect(() => {
+    if (
+      !mapRef.current ||
+      !mapReady ||
+      memoriesLoading ||
+      memories.length === 0
+    )
+      return;
+
+    const params = new URLSearchParams(window.location.search);
+    const memoryIdParam = params.get('memoryId');
+
+    if (!memoryIdParam) return;
+    if (cameraFocusedMemoryParamRef.current === memoryIdParam) return;
+
+    const targetMemory = memories.find((m) => m.id === memoryIdParam);
+    if (!targetMemory) {
+      cameraFocusedMemoryParamRef.current = memoryIdParam;
+      return;
+    }
+
+    cameraFocusedMemoryParamRef.current = memoryIdParam;
 
     // Switch era if needed
     const memoryEra = getEraFromBatchTag(
       targetMemory.tags ?? [],
       targetMemory.createdAt
     );
-    if (eraParam && memoryEra !== activeMapEra) {
-      setActiveMapEra(memoryEra);
-      mapRef.current.setStyle(ERA_MAP_STYLES[memoryEra]);
-    }
-
-    // Wait for style to load, then fly to memory and open modal
-    const onStyleLoad = () => {
-      mapRef.current?.off('style.load', onStyleLoad);
-      setTimeout(() => {
-        flyToMemoryWithSequence(targetMemory, () => {
-          setSelectedMemory(targetMemory);
-          setMemoryDetailOpen(true);
-        });
-      }, 300);
-    };
 
     if (memoryEra !== activeMapEra) {
-      mapRef.current.on('style.load', onStyleLoad);
+      const map = mapRef.current;
+      if (!map) return;
+
+      const onStyleLoad = () => {
+        map.off('style.load', onStyleLoad);
+        setTimeout(() => {
+          flyToMemoryWithSequence(targetMemory);
+        }, 300);
+      };
+
+      map.on('style.load', onStyleLoad);
+      setActiveMapEra(memoryEra);
     } else {
       setTimeout(() => {
-        flyToMemoryWithSequence(targetMemory, () => {
-          setSelectedMemory(targetMemory);
-          setMemoryDetailOpen(true);
-        });
+        flyToMemoryWithSequence(targetMemory);
       }, 300);
     }
-
-    // Clear URL params after processing (optional - keeps URL clean)
-    window.history.replaceState({}, '', window.location.pathname);
   }, [
     memories,
     memoriesLoading,
     activeMapEra,
+    mapReady,
     flyToMemoryWithSequence,
-    setActiveMapEra,
-    setSelectedMemory,
-    setMemoryDetailOpen,
   ]);
 
   // Switch Mapbox style when the active era changes

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -283,6 +283,39 @@ export function MapComponent() {
     handleMemoryClickRef.current(memory);
   }, []);
 
+  const closeNotebookView = useCallback(() => {
+    setMemoryDetailOpen(false);
+    setSelectedMemory(null);
+    setSelectedLandmark(null);
+
+    const params = new URLSearchParams(window.location.search);
+    params.delete('memoryId');
+    params.set('era', String(activeMapEra));
+
+    processedMemoryParamRef.current = null;
+    cameraFocusedMemoryParamRef.current = null;
+
+    const nextUrl = `/map?${params.toString()}`;
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+    if (currentUrl !== nextUrl) {
+      router.replace(nextUrl, { scroll: false });
+    }
+  }, [activeMapEra, router]);
+
+  // Force Escape behavior for notebook mode: close and return to era map URL.
+  useEffect(() => {
+    if (!memoryDetailOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      closeNotebookView();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [memoryDetailOpen, closeNotebookView]);
+
   // ---------------------------------------------------------------------------
   // Batches → FlyTo → Detail handler
   // ---------------------------------------------------------------------------
@@ -615,6 +648,50 @@ export function MapComponent() {
     mapRef.current.setStyle(targetStyle);
   }, [activeMapEra]);
 
+  // Keep URL in sync with notebook state so each opened memory has a stable deep link.
+  useEffect(() => {
+    if (!isClient) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const currentMemoryIdParam = params.get('memoryId');
+
+    // If a memoryId came from an external navigation (e.g., gallery click),
+    // preserve it only until initial notebook selection is established.
+    const hasPendingIncomingMemoryId =
+      !selectedMemory &&
+      !!currentMemoryIdParam &&
+      processedMemoryParamRef.current !== currentMemoryIdParam;
+
+    // Preserve active era in URL for consistency when sharing/reloading.
+    params.set('era', String(activeMapEra));
+
+    if (memoryDetailOpen && selectedMemory?.id) {
+      params.set('memoryId', selectedMemory.id);
+    } else if (!hasPendingIncomingMemoryId) {
+      params.delete('memoryId');
+
+      // Reset processed refs when leaving notebook mode so reopening via URL works
+      // for the same memory ID in a later navigation.
+      processedMemoryParamRef.current = null;
+      cameraFocusedMemoryParamRef.current = null;
+    }
+
+    const nextSearch = params.toString();
+    const nextUrl = nextSearch ? `/map?${nextSearch}` : '/map';
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+
+    if (currentUrl !== nextUrl) {
+      router.replace(nextUrl, { scroll: false });
+    }
+  }, [
+    isClient,
+    activeMapEra,
+    memoryDetailOpen,
+    selectedMemory,
+    selectedMemory?.id,
+    router,
+  ]);
+
   // Re-render marker roots when memory counts update or visibility changes
   useEffect(() => {
     for (const { root, landmark } of markerRootsRef.current) {
@@ -923,7 +1000,13 @@ export function MapComponent() {
       <MemoryDetailModal
         memory={selectedMemory}
         open={memoryDetailOpen}
-        onOpenChange={setMemoryDetailOpen}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            closeNotebookView();
+            return;
+          }
+          setMemoryDetailOpen(true);
+        }}
         onMemoryDeleted={() => setSelectedMemory(null)}
         hasPrevious={
           selectedMemory

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -16,6 +16,7 @@ import { Plus, Filter } from 'lucide-react';
 import { AddMemoryModal } from './add-memory-modal';
 import {
   FilterMemoriesModal,
+  DEFAULT_FILTERS,
   type MemoryFilters,
 } from './map/FilterMemoriesModal';
 import { GroupPanel } from './groups/GroupPanel';
@@ -115,6 +116,8 @@ export function MapComponent() {
   const router = useRouter();
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
+  const processedMemoryParamRef = useRef<string | null>(null);
+  const cameraFocusedMemoryParamRef = useRef<string | null>(null);
   const [mapError, setMapError] = useState<string | null>(null);
   const [isClient, setIsClient] = useState(false);
   const [addMemoryOpen, setAddMemoryOpen] = useState(false);
@@ -156,6 +159,9 @@ export function MapComponent() {
 
   // Read era URL parameter on mount (for homepage → map navigation)
   useEffect(() => {
+    // Always start with clean filters on fresh map entry.
+    setFilters(DEFAULT_FILTERS);
+
     const params = new URLSearchParams(window.location.search);
     const eraParam = params.get('era');
 

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -445,27 +445,6 @@ export function MapComponent() {
     };
   }, [locationSelectionMode, handleLocationSelected]);
 
-  const handleRequestMapSelection = useCallback(
-    (
-      mode: 'landmark' | 'custom',
-      onSelect: (selection: MapLocationSelection) => void
-    ) => {
-      locationSelectionCallbackRef.current = onSelect;
-      setLocationSelectionMode(mode);
-      setPendingLocationSelection(null);
-
-      // Show landmarks when selecting landmark, hide memory pins during selection
-      if (mode === 'landmark') {
-        setShowLandmarks(true);
-      }
-      setShowMemoryPins(false);
-
-      // Re-open the modal after selection or cancel
-      setAddMemoryOpen(true);
-    },
-    []
-  );
-
   useLayoutEffect(() => {
     setIsClient(true);
     if (!MAPBOX_TOKEN) {
@@ -908,7 +887,6 @@ export function MapComponent() {
           }
         }}
         defaultEra={addMemoryEra}
-        onRequestMapSelection={handleRequestMapSelection}
       />
 
       {/* Map Location Selector Overlay */}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -108,6 +108,9 @@ const CAMERA_ANIMATION = {
   essential: true, // Ensures animation is not skipped even if user prefers reduced motion
 };
 
+const DEFAULT_MAP_CENTER: [number, number] = [123.8986, 10.3224];
+const DEFAULT_MAP_ZOOM = 17;
+
 export function MapComponent() {
   const router = useRouter();
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
@@ -284,9 +287,19 @@ export function MapComponent() {
   }, []);
 
   const closeNotebookView = useCallback(() => {
+    const map = mapRef.current;
+
     setMemoryDetailOpen(false);
     setSelectedMemory(null);
     setSelectedLandmark(null);
+
+    // Return to the default overview camera after leaving notebook mode.
+    map?.easeTo({
+      center: DEFAULT_MAP_CENTER,
+      zoom: DEFAULT_MAP_ZOOM,
+      duration: 900,
+      essential: true,
+    });
 
     const params = new URLSearchParams(window.location.search);
     params.delete('memoryId');
@@ -504,8 +517,8 @@ export function MapComponent() {
         const map = new mapboxgl.Map({
           container: mapContainerRef.current,
           style: 'mapbox://styles/mapbox/streets-v12',
-          center: [123.8986, 10.3224],
-          zoom: 17,
+          center: DEFAULT_MAP_CENTER,
+          zoom: DEFAULT_MAP_ZOOM,
           minZoom: 16,
           maxZoom: 22,
           maxBounds: [


### PR DESCRIPTION
- Added stable gallery-to-map deep linking using memoryId + era query params.
- Synced notebook modal state with URL and removed stale memoryId on close/Escape.
- Added explicit notebook close flow to return to era-only map URL.
- Reset map filters on entry to prevent blank map when navigating to an era.

#### **POSSIBLE ISSUE: memoryId is visible in URL but can enforce strict server authorization checks**