### PR TITLE
Scrum 90 mod 010 add basic policy evaluation service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ plans/
 
 # claude
 .claude
+
+# test-results
+test-results/

--- a/src/config/moderation-policy-rules.ts
+++ b/src/config/moderation-policy-rules.ts
@@ -1,0 +1,19 @@
+export interface ModerationPolicyRule {
+  reasonCode: string;
+  keywords: string[];
+}
+
+export const moderationPolicyRules: ModerationPolicyRule[] = [
+  {
+    reasonCode: 'HATE_SPEECH',
+    keywords: ['racial slur', 'ethnic cleansing', 'white power'],
+  },
+  {
+    reasonCode: 'EXPLICIT_CONTENT',
+    keywords: ['porn', 'nude', 'sex tape'],
+  },
+  {
+    reasonCode: 'VIOLENCE',
+    keywords: ['kill them all', 'massacre', 'beheading'],
+  },
+];

--- a/src/services/create-memory-service.ts
+++ b/src/services/create-memory-service.ts
@@ -6,6 +6,10 @@ import {
   canRoleUsePermission,
   resolveGroupMemberRole,
 } from '@/lib/group-permissions';
+import {
+  isContentPrescreeningEnabled,
+  moderationPolicyService,
+} from '@/services/moderation-policy-service';
 
 interface CreateMemoryInput {
   title: string;
@@ -94,6 +98,11 @@ export async function createMemoryService(
     privateGroupId,
   } = input;
 
+  const prescreeningEnabled = isContentPrescreeningEnabled();
+  const moderationResult = prescreeningEnabled
+    ? moderationPolicyService({ title, description })
+    : null;
+
   if (visibility === 'GROUP_ONLY' && !privateGroupId) {
     throw new Error('Group ID is required for group-only memories');
   }
@@ -170,6 +179,10 @@ export async function createMemoryService(
     description,
     mediaURL,
     visibility,
+    ...(prescreeningEnabled && {
+      moderationStatus:
+        moderationResult?.status === 'flag' ? 'PENDING' : 'APPROVED',
+    }),
     creator: {
       connect: { id: creatorId },
     },

--- a/src/services/get-pending-memory-submissions-service.ts
+++ b/src/services/get-pending-memory-submissions-service.ts
@@ -1,0 +1,32 @@
+import { prisma } from '@/lib/prisma';
+
+export async function getFlaggedMemorySubmissionsService() {
+  return prisma.memory.findMany({
+    where: {
+      deletedAt: null,
+      moderationStatus: 'PENDING',
+    },
+    include: {
+      creator: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+      location: {
+        select: {
+          id: true,
+          buildingName: true,
+        },
+      },
+      tags: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+}
+
+export const getPendingMemorySubmissionsService =
+  getFlaggedMemorySubmissionsService;

--- a/src/services/moderation-policy-service.ts
+++ b/src/services/moderation-policy-service.ts
@@ -1,0 +1,52 @@
+import {
+  moderationPolicyRules,
+  type ModerationPolicyRule,
+} from '../config/moderation-policy-rules';
+
+export interface ModerationPolicyInput {
+  title: string;
+  description?: string | null;
+}
+
+export interface ModerationPolicyResult {
+  status: 'pass' | 'flag';
+  reasons: string[];
+}
+
+export function isContentPrescreeningEnabled(): boolean {
+  return (
+    process.env.ENABLE_CONTENT_PRESCREENING?.trim().toLowerCase() === 'true'
+  );
+}
+
+function matchesRule(content: string, rule: ModerationPolicyRule): boolean {
+  return rule.keywords.some((keyword) =>
+    content.includes(keyword.toLowerCase())
+  );
+}
+
+export function moderationPolicyService(
+  input: ModerationPolicyInput
+): ModerationPolicyResult {
+  if (!isContentPrescreeningEnabled()) {
+    return {
+      status: 'pass',
+      reasons: [],
+    };
+  }
+
+  const content = `${input.title} ${input.description ?? ''}`.toLowerCase();
+  const reasons = moderationPolicyRules
+    .filter((rule) => matchesRule(content, rule))
+    .map((rule) => rule.reasonCode);
+
+  return reasons.length > 0
+    ? {
+        status: 'flag',
+        reasons,
+      }
+    : {
+        status: 'pass',
+        reasons: [],
+      };
+}

--- a/tests/moderation-policy-service.test.ts
+++ b/tests/moderation-policy-service.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { moderationPolicyService } from '../src/services/moderation-policy-service';
+
+const originalEnableContentPrescreening =
+  process.env.ENABLE_CONTENT_PRESCREENING;
+
+function restoreFeatureFlag() {
+  if (originalEnableContentPrescreening === undefined) {
+    delete process.env.ENABLE_CONTENT_PRESCREENING;
+    return;
+  }
+
+  process.env.ENABLE_CONTENT_PRESCREENING = originalEnableContentPrescreening;
+}
+
+function runTest(name: string, assertion: () => void) {
+  try {
+    assertion();
+    console.log(`PASS ${name}`);
+  } finally {
+    restoreFeatureFlag();
+  }
+}
+
+runTest('flags content when a configured moderation rule is triggered', () => {
+  process.env.ENABLE_CONTENT_PRESCREENING = 'true';
+
+  const result = moderationPolicyService({
+    title: 'White power rally flyer',
+    description: 'Sharing materials for the event.',
+  });
+
+  assert.deepEqual(result, {
+    status: 'flag',
+    reasons: ['HATE_SPEECH'],
+  });
+});
+
+runTest('passes content when no moderation rules are triggered', () => {
+  process.env.ENABLE_CONTENT_PRESCREENING = 'true';
+
+  const result = moderationPolicyService({
+    title: 'Campus lantern parade',
+    description: 'Photos from the alumni reunion at the oval.',
+  });
+
+  assert.deepEqual(result, {
+    status: 'pass',
+    reasons: [],
+  });
+});
+
+runTest('bypasses moderation checks when the feature flag is disabled', () => {
+  process.env.ENABLE_CONTENT_PRESCREENING = 'false';
+
+  const result = moderationPolicyService({
+    title: 'White power rally flyer',
+    description: 'This would normally trigger a configured rule.',
+  });
+
+  assert.deepEqual(result, {
+    status: 'pass',
+    reasons: [],
+  });
+});


### PR DESCRIPTION
- Added a standalone moderation policy config and a typed prescreening service that returns { status, reasons } and respects ENABLE_CONTENT_PRESCREENING.
- Wired memory creation through the service layer so flagged submissions remain PENDING while passing submissions can proceed without route-level policy logic.
- Added a query helper for pending/flagged moderation queue items and direct unit tests covering flag, pass, and feature-flag bypass behavior.