### PR TITLE
feat(moderation): enforce APPROVED-only visibility in public memory q…

### DIFF
--- a/src/app/api/prisma/memory/comment/create/route.ts
+++ b/src/app/api/prisma/memory/comment/create/route.ts
@@ -77,7 +77,20 @@ export async function POST(request: NextRequest) {
 
     const { memoryId, content } = parsed.data;
 
-    // ── 3. Create comment ──────────────────────────────────────────────────
+    // ── 3. Verify memory is approved ────────────────────────────────────────
+    const memory = await prisma.memory.findFirst({
+      where: { id: memoryId, deletedAt: null, moderationStatus: 'APPROVED' },
+      select: { id: true },
+    });
+
+    if (!memory) {
+      return NextResponse.json(
+        { success: false, message: 'Memory not found' },
+        { status: 404 }
+      );
+    }
+
+    // ── 4. Create comment ──────────────────────────────────────────────────
     const comment = await prisma.memoryComment.create({
       data: { memoryId, authorId: userId, content },
       select: {

--- a/src/app/api/prisma/memory/counts-by-landmark/route.ts
+++ b/src/app/api/prisma/memory/counts-by-landmark/route.ts
@@ -6,7 +6,7 @@ export async function GET() {
   try {
     const counts = await prisma.memory.groupBy({
       by: ['locationId'],
-      where: { deletedAt: null },
+      where: { deletedAt: null, moderationStatus: 'APPROVED' },
       _count: { id: true },
     });
 

--- a/src/app/api/prisma/memory/get-all-with-coordinates/route.ts
+++ b/src/app/api/prisma/memory/get-all-with-coordinates/route.ts
@@ -20,25 +20,32 @@ export async function GET() {
     const memories = await prisma.memory.findMany({
       where: {
         deletedAt: null,
-        OR: [
-          { visibility: 'PUBLIC' },
-          { creator: { id: user.id } },
+        AND: [
           {
-            AND: [
-              { visibility: 'PROGRAM_ONLY' },
-              { programBatch: { students: { some: { id: user.id } } } },
-            ],
+            OR: [{ moderationStatus: 'APPROVED' }, { creatorId: user.id }],
           },
           {
-            AND: [
-              { visibility: 'BATCH_ONLY' },
-              { programBatch: { students: { some: { id: user.id } } } },
-            ],
-          },
-          {
-            AND: [
-              { visibility: 'GROUP_ONLY' },
-              { privateGroup: { members: { some: { id: user.id } } } },
+            OR: [
+              { visibility: 'PUBLIC' },
+              { creator: { id: user.id } },
+              {
+                AND: [
+                  { visibility: 'PROGRAM_ONLY' },
+                  { programBatch: { students: { some: { id: user.id } } } },
+                ],
+              },
+              {
+                AND: [
+                  { visibility: 'BATCH_ONLY' },
+                  { programBatch: { students: { some: { id: user.id } } } },
+                ],
+              },
+              {
+                AND: [
+                  { visibility: 'GROUP_ONLY' },
+                  { privateGroup: { members: { some: { id: user.id } } } },
+                ],
+              },
             ],
           },
         ],

--- a/src/app/api/prisma/memory/get-by-creator/route.ts
+++ b/src/app/api/prisma/memory/get-by-creator/route.ts
@@ -32,8 +32,8 @@ export async function GET(request: NextRequest) {
         creatorId: result.data.userId,
         deletedAt: null,
         isArchived: false,
-        // Non-owners can only see public memories
-        ...(!isOwner && { visibility: 'PUBLIC' }),
+        // Non-owners can only see approved public memories
+        ...(!isOwner && { visibility: 'PUBLIC', moderationStatus: 'APPROVED' }),
       },
       include: {
         tags: true,

--- a/src/app/api/prisma/memory/get-by-group/route.ts
+++ b/src/app/api/prisma/memory/get-by-group/route.ts
@@ -59,6 +59,7 @@ export async function GET(request: Request) {
         privateGroupId: groupId,
         visibility: 'GROUP_ONLY',
         deletedAt: null,
+        OR: [{ moderationStatus: 'APPROVED' }, { creatorId: user.id }],
       },
       include: {
         creator: {

--- a/src/app/api/prisma/memory/get-by-location/route.ts
+++ b/src/app/api/prisma/memory/get-by-location/route.ts
@@ -39,25 +39,32 @@ export async function GET(request: NextRequest) {
       where: {
         locationId,
         deletedAt: null,
-        OR: [
-          { visibility: 'PUBLIC' },
-          { creator: { id: user.id } },
+        AND: [
           {
-            AND: [
-              { visibility: 'PROGRAM_ONLY' },
-              { programBatch: { students: { some: { id: user.id } } } },
-            ],
+            OR: [{ moderationStatus: 'APPROVED' }, { creatorId: user.id }],
           },
           {
-            AND: [
-              { visibility: 'BATCH_ONLY' },
-              { programBatch: { students: { some: { id: user.id } } } },
-            ],
-          },
-          {
-            AND: [
-              { visibility: 'GROUP_ONLY' },
-              { privateGroup: { members: { some: { id: user.id } } } },
+            OR: [
+              { visibility: 'PUBLIC' },
+              { creator: { id: user.id } },
+              {
+                AND: [
+                  { visibility: 'PROGRAM_ONLY' },
+                  { programBatch: { students: { some: { id: user.id } } } },
+                ],
+              },
+              {
+                AND: [
+                  { visibility: 'BATCH_ONLY' },
+                  { programBatch: { students: { some: { id: user.id } } } },
+                ],
+              },
+              {
+                AND: [
+                  { visibility: 'GROUP_ONLY' },
+                  { privateGroup: { members: { some: { id: user.id } } } },
+                ],
+              },
             ],
           },
         ],

--- a/src/app/api/prisma/memory/vote/toggle/route.ts
+++ b/src/app/api/prisma/memory/vote/toggle/route.ts
@@ -114,7 +114,20 @@ export async function POST(request: NextRequest) {
 
     const { memoryId } = parsed.data;
 
-    // ── 3. Rate limit ──────────────────────────────────────────────────────
+    // ── 3. Verify memory is approved ────────────────────────────────────────
+    const memory = await prisma.memory.findFirst({
+      where: { id: memoryId, deletedAt: null, moderationStatus: 'APPROVED' },
+      select: { id: true },
+    });
+
+    if (!memory) {
+      return NextResponse.json(
+        { success: false, message: 'Memory not found' },
+        { status: 404 }
+      );
+    }
+
+    // ── 4. Rate limit ──────────────────────────────────────────────────────
     if (isRateLimited(userId, memoryId)) {
       return NextResponse.json(
         { success: false, message: 'Too many requests — slow down.' },
@@ -122,7 +135,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // ── 4. Toggle vote ─────────────────────────────────────────────────────
+    // ── 5. Toggle vote ─────────────────────────────────────────────────────
     const result = await toggleVoteService(memoryId, userId);
 
     return NextResponse.json({


### PR DESCRIPTION
…ueries

Add moderationStatus filtering to all user-facing memory endpoints so unreviewed content is never publicly exposed. Creators can still see their own non-approved memories. Voting and commenting on non-approved memories is now blocked with a 404 guard.