### PR TITLE
feat(moderation): add audit log view for reviewing moderation decisions

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,6 +15,8 @@ import {
   XCircle,
   Loader2,
   RefreshCw,
+  ChevronDown,
+  ArrowUpDown,
 } from 'lucide-react';
 import Image from 'next/image';
 import {
@@ -27,13 +29,19 @@ import {
   type AdminReportItem,
 } from '@/lib/hooks/useAdminReports';
 import { useResolveReport } from '@/lib/hooks/useResolveReport';
+import {
+  useAuditLog,
+  type AuditLogFilters,
+  type AuditLogEntry,
+} from '@/lib/hooks/useAuditLog';
 
-type AdminTab = 'published' | 'pending' | 'reports';
+type AdminTab = 'published' | 'pending' | 'reports' | 'audit';
 
 const tabLabels: Record<AdminTab, string> = {
   published: 'Published Posts',
   pending: 'Pending Review',
   reports: 'Reports',
+  audit: 'Audit Log',
 };
 
 function formatDate(dateString: string): string {
@@ -385,12 +393,224 @@ function ReportsContent({ searchQuery }: { searchQuery: string }) {
   );
 }
 
+const ACTION_LABELS: Record<string, string> = {
+  MEMORY_APPROVED: 'Memory Approved',
+  MEMORY_REJECTED: 'Memory Rejected',
+  MEMORY_REMOVED: 'Memory Removed',
+  MEMORY_RESTORED: 'Memory Restored',
+  REPORT_OPENED: 'Report Opened',
+  REPORT_RESOLVED: 'Report Resolved',
+  REPORT_DISMISSED: 'Report Dismissed',
+};
+
+const ACTION_COLORS: Record<string, string> = {
+  MEMORY_APPROVED: 'bg-green-50 text-green-600',
+  MEMORY_REJECTED: 'bg-yellow-50 text-yellow-600',
+  MEMORY_REMOVED: 'bg-red-50 text-red-600',
+  MEMORY_RESTORED: 'bg-blue-50 text-blue-600',
+  REPORT_OPENED: 'bg-red-50 text-red-600',
+  REPORT_RESOLVED: 'bg-green-50 text-green-600',
+  REPORT_DISMISSED: 'bg-secondary text-muted-foreground',
+};
+
+const ALL_ACTIONS = [
+  'MEMORY_APPROVED',
+  'MEMORY_REJECTED',
+  'MEMORY_REMOVED',
+  'MEMORY_RESTORED',
+  'REPORT_OPENED',
+  'REPORT_RESOLVED',
+  'REPORT_DISMISSED',
+] as const;
+
+function AuditLogContent({ searchQuery }: { searchQuery: string }) {
+  const [actionFilter, setActionFilter] = useState<string>('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [sort, setSort] = useState<'asc' | 'desc'>('desc');
+
+  const filters: AuditLogFilters = {
+    action: actionFilter || undefined,
+    dateFrom: dateFrom ? new Date(dateFrom).toISOString() : undefined,
+    dateTo: dateTo
+      ? new Date(dateTo + 'T23:59:59.999Z').toISOString()
+      : undefined,
+    sort,
+  };
+
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useAuditLog(filters);
+
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState onRetry={() => refetch()} />;
+
+  const allEntries = data?.pages.flatMap((page) => page.data.items) ?? [];
+
+  const filtered = allEntries.filter((entry) => {
+    if (!searchQuery) return true;
+    const query = searchQuery.toLowerCase();
+    const adminName =
+      `${entry.admin.firstName} ${entry.admin.lastName}`.toLowerCase();
+    const targetTitle =
+      entry.targetMemory?.title?.toLowerCase() ??
+      entry.targetReport?.reason?.toLowerCase() ??
+      '';
+    return adminName.includes(query) || targetTitle.includes(query);
+  });
+
+  function getTargetLabel(entry: AuditLogEntry): string {
+    if (entry.targetType === 'MEMORY') {
+      return entry.targetMemory?.title ?? 'Deleted memory';
+    }
+    if (entry.targetType === 'REPORT') {
+      return entry.targetReport
+        ? `Report: ${entry.targetReport.reason}`
+        : 'Deleted report';
+    }
+    return 'Unknown target';
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter Bar */}
+      <div className="flex flex-wrap items-center gap-3 border-2 border-border bg-card p-3">
+        {/* Action type filter */}
+        <div className="relative">
+          <select
+            value={actionFilter}
+            onChange={(e) => setActionFilter(e.target.value)}
+            className="appearance-none border-2 border-border bg-background py-1.5 pl-3 pr-8 text-xs focus:border-skolaroid-blue focus:outline-none"
+          >
+            <option value="">All Actions</option>
+            {ALL_ACTIONS.map((action) => (
+              <option key={action} value={action}>
+                {ACTION_LABELS[action]}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            size={12}
+            className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+        </div>
+
+        {/* Date range */}
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span>From</span>
+          <input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+            className="border-2 border-border bg-background px-2 py-1.5 text-xs focus:border-skolaroid-blue focus:outline-none"
+          />
+          <span>to</span>
+          <input
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+            className="border-2 border-border bg-background px-2 py-1.5 text-xs focus:border-skolaroid-blue focus:outline-none"
+          />
+        </div>
+
+        {/* Sort toggle */}
+        <button
+          onClick={() => setSort((s) => (s === 'desc' ? 'asc' : 'desc'))}
+          className="flex items-center gap-1.5 border-2 border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-secondary"
+        >
+          <ArrowUpDown size={12} />
+          {sort === 'desc' ? 'Newest first' : 'Oldest first'}
+        </button>
+      </div>
+
+      {/* Entries */}
+      {filtered.length === 0 ? (
+        <div className="py-16 text-center text-sm text-muted-foreground">
+          No moderation actions found.
+        </div>
+      ) : (
+        <>
+          {filtered.map((entry) => {
+            const adminName = `${entry.admin.firstName} ${entry.admin.lastName}`;
+            return (
+              <div
+                key={entry.id}
+                className="flex items-start gap-4 border-2 border-border bg-card p-4 shadow-[4px_4px_0px_0px_#2d2d2d]"
+              >
+                {/* Admin avatar */}
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-skolaroid-blue text-sm font-medium text-white">
+                  {entry.admin.firstName.charAt(0)}
+                </div>
+
+                {/* Content */}
+                <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">
+                      {adminName}
+                    </span>
+                    <span
+                      className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium ${ACTION_COLORS[entry.action] ?? 'bg-secondary text-muted-foreground'}`}
+                    >
+                      {ACTION_LABELS[entry.action] ?? entry.action}
+                    </span>
+                  </div>
+
+                  <p className="text-xs text-muted-foreground">
+                    {getTargetLabel(entry)}
+                  </p>
+
+                  {entry.reason && (
+                    <p className="text-xs italic text-muted-foreground">
+                      Reason: {entry.reason}
+                    </p>
+                  )}
+
+                  <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Clock size={10} />
+                    {formatDate(entry.createdAt)}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+
+          {/* Load More */}
+          {hasNextPage && (
+            <div className="flex justify-center pt-2">
+              <button
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+                className="flex items-center gap-1.5 border-2 border-border px-4 py-2 text-xs text-muted-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+              >
+                {isFetchingNextPage ? (
+                  <>
+                    <Loader2 size={12} className="animate-spin" />
+                    Loading...
+                  </>
+                ) : (
+                  'Load More'
+                )}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function AdminPage() {
   const router = useRouter();
   const [currentTab, setCurrentTab] = useState<AdminTab>('published');
   const [searchQuery, setSearchQuery] = useState('');
 
-  const tabs: AdminTab[] = ['published', 'pending', 'reports'];
+  const tabs: AdminTab[] = ['published', 'pending', 'reports', 'audit'];
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -456,6 +676,9 @@ export default function AdminPage() {
         )}
         {currentTab === 'reports' && (
           <ReportsContent searchQuery={searchQuery} />
+        )}
+        {currentTab === 'audit' && (
+          <AuditLogContent searchQuery={searchQuery} />
         )}
       </main>
     </div>

--- a/src/app/api/prisma/moderation/audit-log/route.ts
+++ b/src/app/api/prisma/moderation/audit-log/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auditLogQuerySchema } from '@/lib/schemas';
+import { requireAdmin } from '@/lib/utils/require-admin';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(request: NextRequest) {
+  try {
+    const result = await requireAdmin();
+    if ('error' in result) return result.error;
+
+    const { searchParams } = new URL(request.url);
+    const parsed = auditLogQuerySchema.safeParse({
+      action: searchParams.get('action') ?? undefined,
+      adminId: searchParams.get('adminId') ?? undefined,
+      dateFrom: searchParams.get('dateFrom') ?? undefined,
+      dateTo: searchParams.get('dateTo') ?? undefined,
+      cursor: searchParams.get('cursor') ?? undefined,
+      limit: searchParams.get('limit') ?? undefined,
+      sort: searchParams.get('sort') ?? undefined,
+    });
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? 'Validation failed',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { action, adminId, dateFrom, dateTo, cursor, limit, sort } =
+      parsed.data;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: Record<string, any> = {};
+    if (action) where.action = action;
+    if (adminId) where.adminId = adminId;
+    if (dateFrom || dateTo) {
+      where.createdAt = {};
+      if (dateFrom) where.createdAt.gte = dateFrom;
+      if (dateTo) where.createdAt.lte = dateTo;
+    }
+
+    const rows = await prisma.moderationActionLog.findMany({
+      where,
+      orderBy: { createdAt: sort },
+      take: limit + 1,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      include: {
+        admin: { select: { id: true, firstName: true, lastName: true } },
+        targetMemory: { select: { id: true, title: true } },
+        targetReport: { select: { id: true, reason: true, state: true } },
+      },
+    });
+
+    const hasMore = rows.length > limit;
+    const items = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore ? (items[items.length - 1]?.id ?? null) : null;
+
+    return NextResponse.json({
+      success: true,
+      message: 'Audit log fetched successfully',
+      data: { items, nextCursor, hasMore },
+    });
+  } catch (error) {
+    console.error('[GET /api/prisma/moderation/audit-log]', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Unable to fetch audit log. Please try again.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/hooks/useAuditLog.ts
+++ b/src/lib/hooks/useAuditLog.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export interface AuditLogFilters {
+  action?: string;
+  adminId?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  sort?: 'asc' | 'desc';
+}
+
+export interface AuditLogEntry {
+  id: string;
+  adminId: string;
+  action: string;
+  targetType: 'MEMORY' | 'REPORT';
+  targetMemoryId: string | null;
+  targetReportId: string | null;
+  reason: string | null;
+  createdAt: string;
+  admin: { id: string; firstName: string; lastName: string };
+  targetMemory: { id: string; title: string } | null;
+  targetReport: { id: string; reason: string; state: string } | null;
+}
+
+interface AuditLogPage {
+  success: boolean;
+  data: {
+    items: AuditLogEntry[];
+    nextCursor: string | null;
+    hasMore: boolean;
+  };
+}
+
+export function useAuditLog(filters: AuditLogFilters) {
+  return useInfiniteQuery({
+    queryKey: ['audit-log', filters],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams();
+      if (filters.action) params.set('action', filters.action);
+      if (filters.adminId) params.set('adminId', filters.adminId);
+      if (filters.dateFrom) params.set('dateFrom', filters.dateFrom);
+      if (filters.dateTo) params.set('dateTo', filters.dateTo);
+      if (filters.sort) params.set('sort', filters.sort);
+      if (pageParam) params.set('cursor', pageParam);
+
+      const res = await fetch(`/api/prisma/moderation/audit-log?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch audit log');
+      return res.json() as Promise<AuditLogPage>;
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.data.nextCursor ?? undefined,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -424,6 +424,29 @@ export type ModerationStatus = z.infer<typeof moderationStatusEnum>;
 export type ModerateMemoryInput = z.infer<typeof moderateMemorySchema>;
 export type ResolveReportInput = z.infer<typeof resolveReportSchema>;
 
+export const moderationActionTypeEnum = z.enum([
+  'MEMORY_APPROVED',
+  'MEMORY_REJECTED',
+  'MEMORY_REMOVED',
+  'MEMORY_RESTORED',
+  'REPORT_OPENED',
+  'REPORT_RESOLVED',
+  'REPORT_DISMISSED',
+]);
+
+/** Query params for fetching the moderation audit log (admin). */
+export const auditLogQuerySchema = z.object({
+  action: moderationActionTypeEnum.optional(),
+  adminId: z.string().uuid('Invalid admin ID').optional(),
+  dateFrom: z.coerce.date().optional(),
+  dateTo: z.coerce.date().optional(),
+  cursor: z.string().uuid('Invalid cursor').optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  sort: z.enum(['asc', 'desc']).default('desc'),
+});
+
+export type AuditLogQuery = z.infer<typeof auditLogQuerySchema>;
+
 // ============================================================================
 // AUTH TYPE EXPORTS
 // ============================================================================


### PR DESCRIPTION
## Overview
Adds an admin-only "Audit Log" tab to the admin dashboard (/admin) that displays the complete history of moderation actions taken on the platform.

## Features
- **Filter by action type**: MEMORY_APPROVED, MEMORY_REJECTED, MEMORY_REMOVED, MEMORY_RESTORED, REPORT_OPENED, REPORT_RESOLVED, REPORT_DISMISSED
- **Filter by date range**: Select from/to dates to view actions in a specific timeframe
- **Filter by admin**: Can be expanded to show only actions by specific admins
- **Sort**: Toggle between newest-first (default) and oldest-first ordering
- **Pagination**: Cursor-based infinite scroll with "Load More" button (20 entries per page)
- **Search**: Client-side search across admin names and affected memory/report titles
- **Links**: Each entry shows the admin who acted, the action type (color-coded), the affected memory or report, any reason provided, and the timestamp

## How to Access
1. Navigate to /admin in your browser
2. Click the "Audit Log" tab (4th tab in the navigation)
3. Must be logged in as a user with ADMIN role (if not admin, API returns 403)

## How to Use
1. **View all actions**: No filters applied by default—all recent moderation actions load immediately
2. **Filter by action**: Use the dropdown to select a specific action type (e.g., "Memory Approved")
3. **Filter by date**: Set "From" and/or "To" dates to narrow to a timeframe
4. **Search**: Use the search bar to find actions by admin name or affected memory/report title
5. **Sort**: Click the "Newest first" / "Oldest first" button to reverse the order
6. **Load more**: Scroll to the bottom and click "Load More" to fetch the next page
7. **View details**: Each audit entry shows admin avatar, action badge, target (memory/report), reason, and timestamp