### PR TITLE
Scrum 102 search 2 search api route schema

### DIFF
--- a/src/app/api/prisma/memory/[memoryId]/edit/route.ts
+++ b/src/app/api/prisma/memory/[memoryId]/edit/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import { editMemoryServerSchema } from '@/lib/schemas';
+import { updateMemoryService } from '@/services/update-memory-service';
+
+/**
+ * PATCH /api/prisma/memory/[memoryId]/edit
+ *
+ * Updates a memory's title, description, tags, visibility, or privateGroupId.
+ * Only the creator or a platform admin may edit a memory.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ memoryId: string }> }
+) {
+  try {
+    const { memoryId } = await params;
+
+    // ── 1. Authenticate ──────────────────────────────────────────────
+    const supabase = await createClient();
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, message: 'Not authenticated' },
+        { status: 401 }
+      );
+    }
+
+    // ── 2. Fetch memory + actor role in parallel ──────────────────────
+    const [memory, dbUser] = await Promise.all([
+      prisma.memory.findUnique({
+        where: { id: memoryId, deletedAt: null },
+        select: { id: true, creatorId: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: authUser.id },
+        select: { role: true },
+      }),
+    ]);
+
+    if (!memory) {
+      return NextResponse.json(
+        { success: false, message: 'Memory not found' },
+        { status: 404 }
+      );
+    }
+
+    const isAdmin = dbUser?.role === 'ADMIN';
+
+    if (memory.creatorId !== authUser.id && !isAdmin) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Only the creator or an admin can edit this memory',
+        },
+        { status: 403 }
+      );
+    }
+
+    // ── 3. Validate body ─────────────────────────────────────────────
+    const body = await request.json();
+    const parsed = editMemoryServerSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? 'Invalid input',
+        },
+        { status: 400 }
+      );
+    }
+
+    // ── 4. Service ───────────────────────────────────────────────────
+    await updateMemoryService({
+      memoryId,
+      actorId: authUser.id,
+      isAdmin,
+      data: parsed.data,
+    });
+
+    // ── 5. Return updated memory with relations ───────────────────────
+    const updated = await prisma.memory.findUnique({
+      where: { id: memoryId },
+      include: {
+        tags: true,
+        location: { select: { id: true, buildingName: true } },
+        creator: { select: { firstName: true, lastName: true } },
+        _count: { select: { votes: true, comments: true } },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Memory updated successfully',
+      data: updated,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+
+    if (message === 'Memory not found' || message === 'Group not found') {
+      return NextResponse.json({ success: false, message }, { status: 404 });
+    }
+
+    if (
+      message === 'You are not a member of this group' ||
+      message === 'Your role cannot post in this group' ||
+      message === 'Group ID is required for group-only memories'
+    ) {
+      return NextResponse.json({ success: false, message }, { status: 400 });
+    }
+
+    console.error('[memory/edit] Error:', message);
+    return NextResponse.json(
+      { success: false, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/prisma/search/route.ts
+++ b/src/app/api/prisma/search/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { searchQuerySchema } from '@/lib/schemas';
+import { searchService } from '@/services/search-service';
+
+/**
+ * GET /api/prisma/search
+ *
+ * Global search endpoint across Memories, Users, Locations, Tags, and Batches.
+ * Enforces memory visibility rules based on the authenticated user's cohorts and groups.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // ── 1. Authenticate ──────────────────────────────────────────────
+    const supabase = await createClient();
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, message: 'Not authenticated' },
+        { status: 401 }
+      );
+    }
+
+    // ── 2. ValidateQueryParams ───────────────────────────────────────
+    const { searchParams } = new URL(request.url);
+    const query = {
+      q: searchParams.get('q') || '',
+      page: searchParams.get('page'),
+      limit: searchParams.get('limit'),
+    };
+
+    const parsed = searchQuerySchema.safeParse(query);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            parsed.error.issues[0]?.message ?? 'Invalid search parameters',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { q, page, limit } = parsed.data;
+
+    // ── 3. Execute Search Service ────────────────────────────────────
+    const searchData = await searchService(q, authUser.id, page, limit);
+
+    // ── 4. Return Data ───────────────────────────────────────────────
+    return NextResponse.json({
+      success: true,
+      message: 'Search completed successfully',
+      data: searchData,
+    });
+  } catch (error) {
+    console.error('[search/route] Error:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+
+    if (message === 'User not found') {
+      return NextResponse.json({ success: false, message }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      { success: false, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/group-permissions.ts
+++ b/src/lib/group-permissions.ts
@@ -1,5 +1,3 @@
-import { prisma } from '@/lib/prisma';
-
 export const GROUP_ROLES = ['OWNER', 'ADMIN', 'MEMBER'] as const;
 export type GroupMemberRole = (typeof GROUP_ROLES)[number];
 
@@ -109,47 +107,4 @@ export function resolveGroupMemberRole(
   }
 
   return 'MEMBER';
-}
-
-export async function assertCanPostInGroup(
-  actorId: string,
-  privateGroupId: string
-): Promise<void> {
-  const group = await prisma.privateGroup.findUnique({
-    where: { id: privateGroupId, deletedAt: null },
-    select: {
-      id: true,
-      creatorId: true,
-      rolePrivileges: true,
-      members: {
-        where: { id: actorId },
-        select: { id: true },
-      },
-      groupMemberships: {
-        where: { userId: actorId },
-        select: { role: true },
-      },
-    },
-  });
-
-  if (!group) {
-    throw new Error('Group not found');
-  }
-
-  const isMember =
-    group.members.length > 0 || group.groupMemberships.length > 0;
-
-  if (!isMember) {
-    throw new Error('You are not a member of this group');
-  }
-
-  const role = resolveGroupMemberRole(
-    actorId,
-    group.creatorId,
-    group.groupMemberships[0]?.role
-  );
-
-  if (!canRoleUsePermission(group.rolePrivileges, role, 'editContent')) {
-    throw new Error('Your role cannot post in this group');
-  }
 }

--- a/src/lib/group-permissions.ts
+++ b/src/lib/group-permissions.ts
@@ -1,3 +1,5 @@
+import { prisma } from '@/lib/prisma';
+
 export const GROUP_ROLES = ['OWNER', 'ADMIN', 'MEMBER'] as const;
 export type GroupMemberRole = (typeof GROUP_ROLES)[number];
 
@@ -107,4 +109,47 @@ export function resolveGroupMemberRole(
   }
 
   return 'MEMBER';
+}
+
+export async function assertCanPostInGroup(
+  actorId: string,
+  privateGroupId: string
+): Promise<void> {
+  const group = await prisma.privateGroup.findUnique({
+    where: { id: privateGroupId, deletedAt: null },
+    select: {
+      id: true,
+      creatorId: true,
+      rolePrivileges: true,
+      members: {
+        where: { id: actorId },
+        select: { id: true },
+      },
+      groupMemberships: {
+        where: { userId: actorId },
+        select: { role: true },
+      },
+    },
+  });
+
+  if (!group) {
+    throw new Error('Group not found');
+  }
+
+  const isMember =
+    group.members.length > 0 || group.groupMemberships.length > 0;
+
+  if (!isMember) {
+    throw new Error('You are not a member of this group');
+  }
+
+  const role = resolveGroupMemberRole(
+    actorId,
+    group.creatorId,
+    group.groupMemberships[0]?.role
+  );
+
+  if (!canRoleUsePermission(group.rolePrivileges, role, 'editContent')) {
+    throw new Error('Your role cannot post in this group');
+  }
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -123,8 +123,6 @@ export const searchQuerySchema = z.object({
 
 export type SearchQueryInput = z.infer<typeof searchQuerySchema>;
 
-export type EditMemoryInput = z.infer<typeof editMemoryServerSchema>;
-
 /** Schema for updating tags on an existing memory. */
 export const updateMemoryTagsSchema = z.object({
   memoryId: z.string().uuid('Invalid memory ID'),

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -111,6 +111,20 @@ export const editMemoryServerSchema = editMemorySchema;
 
 export type EditMemoryInput = z.infer<typeof editMemoryServerSchema>;
 
+// ============================================================================
+// GLOBAL SEARCH SCHEMAS
+// ============================================================================
+
+export const searchQuerySchema = z.object({
+  q: z.string().trim().min(1, 'Search query cannot be empty'),
+  page: z.coerce.number().int().min(1).catch(1),
+  limit: z.coerce.number().int().min(1).max(50).catch(20),
+});
+
+export type SearchQueryInput = z.infer<typeof searchQuerySchema>;
+
+export type EditMemoryInput = z.infer<typeof editMemoryServerSchema>;
+
 /** Schema for updating tags on an existing memory. */
 export const updateMemoryTagsSchema = z.object({
   memoryId: z.string().uuid('Invalid memory ID'),

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -81,6 +81,36 @@ export const createMemoryServerSchema = createMemorySchema.extend({
   privateGroupId: z.string().uuid('Invalid group ID').optional(),
 });
 
+/** Client-side schema for editing a memory — all fields optional, at least one required. */
+export const editMemorySchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, 'Title is required')
+      .max(255, 'Title must be 255 characters or less')
+      .optional(),
+    description: z
+      .string()
+      .trim()
+      .max(5000, 'Description is too long')
+      .optional(),
+    visibility: memoryVisibilityEnum.optional(),
+    tags: z
+      .array(z.string().trim().min(1).max(50))
+      .max(MAX_TAGS, 'Maximum 10 tags')
+      .optional(),
+    privateGroupId: z.string().uuid('Invalid group ID').nullable().optional(),
+  })
+  .refine((v) => Object.values(v).some((x) => x !== undefined), {
+    message: 'At least one field must be provided',
+  });
+
+/** Server-side schema for editing a memory — no additional coercions needed. */
+export const editMemoryServerSchema = editMemorySchema;
+
+export type EditMemoryInput = z.infer<typeof editMemoryServerSchema>;
+
 /** Schema for updating tags on an existing memory. */
 export const updateMemoryTagsSchema = z.object({
   memoryId: z.string().uuid('Invalid memory ID'),

--- a/src/lib/server/group-permissions.ts
+++ b/src/lib/server/group-permissions.ts
@@ -1,0 +1,48 @@
+import { prisma } from '@/lib/prisma';
+import {
+  canRoleUsePermission,
+  resolveGroupMemberRole,
+} from '@/lib/group-permissions';
+
+export async function assertCanPostInGroup(
+  actorId: string,
+  privateGroupId: string
+): Promise<void> {
+  const group = await prisma.privateGroup.findUnique({
+    where: { id: privateGroupId, deletedAt: null },
+    select: {
+      id: true,
+      creatorId: true,
+      rolePrivileges: true,
+      members: {
+        where: { id: actorId },
+        select: { id: true },
+      },
+      groupMemberships: {
+        where: { userId: actorId },
+        select: { role: true },
+      },
+    },
+  });
+
+  if (!group) {
+    throw new Error('Group not found');
+  }
+
+  const isMember =
+    group.members.length > 0 || group.groupMemberships.length > 0;
+
+  if (!isMember) {
+    throw new Error('You are not a member of this group');
+  }
+
+  const role = resolveGroupMemberRole(
+    actorId,
+    group.creatorId,
+    group.groupMemberships[0]?.role
+  );
+
+  if (!canRoleUsePermission(group.rolePrivileges, role, 'editContent')) {
+    throw new Error('Your role cannot post in this group');
+  }
+}

--- a/src/lib/utils/memory-tags.ts
+++ b/src/lib/utils/memory-tags.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@/lib/prisma';
+import { findNearestLandmark } from '@/lib/utils/map-utils';
+
+export async function generateAutoTags(
+  locationId: string,
+  memoryDate?: Date
+): Promise<string[]> {
+  const autoTags: string[] = [];
+
+  const location = await prisma.location.findUnique({
+    where: { id: locationId },
+    select: {
+      buildingName: true,
+      latitude: true,
+      longitude: true,
+    },
+  });
+
+  if (!location) {
+    throw new Error(`Location with ID ${locationId} not found`);
+  }
+
+  const { buildingName, latitude, longitude } = location;
+
+  if (buildingName) {
+    autoTags.push(buildingName);
+  } else {
+    const nearest = findNearestLandmark({ latitude, longitude });
+    if (nearest) {
+      autoTags.push(`Near ${nearest.landmark.name}`);
+    }
+  }
+
+  const referenceYear = memoryDate
+    ? memoryDate.getFullYear()
+    : new Date().getFullYear();
+  const decade = Math.floor(referenceYear / 10) * 10;
+  autoTags.push(`${decade}s`);
+
+  if (memoryDate) {
+    autoTags.push(`${referenceYear}`);
+  }
+
+  return autoTags;
+}

--- a/src/services/create-memory-service.ts
+++ b/src/services/create-memory-service.ts
@@ -2,10 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { slugify } from '@/lib/slugify';
 import { MAX_TAGS, type MemoryVisibility } from '@/lib/schemas';
 import { generateAutoTags } from '@/lib/utils/memory-tags';
-import {
-  canRoleUsePermission,
-  resolveGroupMemberRole,
-} from '@/lib/group-permissions';
+import { assertCanPostInGroup } from '@/lib/group-permissions';
 import {
   isContentPrescreeningEnabled,
   moderationPolicyService,
@@ -52,43 +49,7 @@ export async function createMemoryService(
   }
 
   if (privateGroupId) {
-    const group = await prisma.privateGroup.findUnique({
-      where: { id: privateGroupId, deletedAt: null },
-      select: {
-        id: true,
-        creatorId: true,
-        rolePrivileges: true,
-        members: {
-          where: { id: creatorId },
-          select: { id: true },
-        },
-        groupMemberships: {
-          where: { userId: creatorId },
-          select: { role: true },
-        },
-      },
-    });
-
-    if (!group) {
-      throw new Error('Group not found');
-    }
-
-    const isMemberInGroup =
-      group.members.length > 0 || group.groupMemberships.length > 0;
-
-    if (!isMemberInGroup) {
-      throw new Error('You are not a member of this group');
-    }
-
-    const role = resolveGroupMemberRole(
-      creatorId,
-      group.creatorId,
-      group.groupMemberships[0]?.role
-    );
-
-    if (!canRoleUsePermission(group.rolePrivileges, role, 'editContent')) {
-      throw new Error('Your role cannot post in this group');
-    }
+    await assertCanPostInGroup(creatorId, privateGroupId);
   }
 
   // Generate auto-tags

--- a/src/services/create-memory-service.ts
+++ b/src/services/create-memory-service.ts
@@ -2,7 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { slugify } from '@/lib/slugify';
 import { MAX_TAGS, type MemoryVisibility } from '@/lib/schemas';
 import { generateAutoTags } from '@/lib/utils/memory-tags';
-import { assertCanPostInGroup } from '@/lib/group-permissions';
+import { assertCanPostInGroup } from '@/lib/server/group-permissions';
 import {
   isContentPrescreeningEnabled,
   moderationPolicyService,

--- a/src/services/create-memory-service.ts
+++ b/src/services/create-memory-service.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { slugify } from '@/lib/slugify';
-import { findNearestLandmark } from '@/lib/utils/map-utils';
 import { MAX_TAGS, type MemoryVisibility } from '@/lib/schemas';
+import { generateAutoTags } from '@/lib/utils/memory-tags';
 import {
   canRoleUsePermission,
   resolveGroupMemberRole,
@@ -23,62 +23,6 @@ interface CreateMemoryInput {
   creatorId: string;
   privateGroupId?: string;
 }
-/**
- * Generate auto-tags for a memory based on location and date
- */
-async function generateAutoTags(
-  locationId: string,
-  memoryDate?: Date
-): Promise<string[]> {
-  const autoTags: string[] = [];
-
-  // 1. Fetch location to get coordinates and buildingName
-  const location = await prisma.location.findUnique({
-    where: { id: locationId },
-    select: {
-      buildingName: true,
-      latitude: true,
-      longitude: true,
-    },
-  });
-
-  if (!location) {
-    throw new Error(`Location with ID ${locationId} not found`);
-  }
-
-  // 2. Generate landmark tag
-  const { buildingName, latitude, longitude } = location;
-
-  if (buildingName) {
-    // Use buildingName directly if it's a known landmark
-    autoTags.push(buildingName);
-  } else {
-    // For custom locations, find nearest landmark and create "Near X" tag
-    const nearest = findNearestLandmark({ latitude, longitude });
-    if (nearest && nearest.distance < 100) {
-      // Within 100 meters
-      autoTags.push(`Near ${nearest.landmark.name}`);
-    } else if (nearest) {
-      // Fallback to nearest landmark name even if far
-      autoTags.push(`Near ${nearest.landmark.name}`);
-    }
-  }
-
-  // 3. Generate era tag (decade)
-  const referenceYear = memoryDate
-    ? memoryDate.getFullYear()
-    : new Date().getFullYear();
-  const decade = Math.floor(referenceYear / 10) * 10;
-  autoTags.push(`${decade}s`);
-
-  // 4. Generate year tag (only if memoryDate is provided)
-  if (memoryDate) {
-    autoTags.push(`${referenceYear}`);
-  }
-
-  return autoTags;
-}
-
 /**
  * Create a memory with auto-generated tags
  */

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -1,0 +1,183 @@
+import { prisma } from '@/lib/prisma';
+
+export async function searchService(
+  query: string,
+  actorId: string,
+  page: number,
+  limit: number
+) {
+  const skip = (page - 1) * limit;
+  const searchFilter = { contains: query, mode: 'insensitive' as const };
+
+  // 1. Get actor's cohorts and groups to enforce visibility rules
+  const user = await prisma.user.findUnique({
+    where: { id: actorId, deletedAt: null },
+    select: {
+      programBatchId: true,
+      groupMemberships: { select: { groupId: true } },
+    },
+  });
+
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  const userGroupIds = user.groupMemberships.map(
+    (membership: { groupId: string }) => membership.groupId
+  );
+
+  // 2. Build Memory Visibility Filter
+  const memoryVisibilityFilter = {
+    OR: [
+      { visibility: 'PUBLIC' as const },
+      {
+        visibility: 'PROGRAM_ONLY' as const,
+        creator: { programBatchId: user.programBatchId },
+      },
+      {
+        visibility: 'BATCH_ONLY' as const,
+        creator: { programBatchId: user.programBatchId },
+      },
+      {
+        visibility: 'GROUP_ONLY' as const,
+        privateGroupId: { in: userGroupIds },
+      },
+      { visibility: 'PRIVATE' as const, creatorId: actorId },
+    ],
+  };
+
+  // 3. Execute Searches Concurrently
+  const [users, memories, locations, tags, batches] = await Promise.all([
+    // USERS
+    prisma.user.findMany({
+      where: {
+        deletedAt: null,
+        OR: [
+          { firstName: searchFilter },
+          { lastName: searchFilter },
+          { email: searchFilter },
+        ],
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        programBatch: {
+          select: {
+            program: { select: { name: true } },
+            batch: { select: { year: true } },
+          },
+        },
+      },
+      skip,
+      take: limit,
+      orderBy: { lastName: 'asc' },
+    }),
+
+    // MEMORIES
+    prisma.memory.findMany({
+      where: {
+        deletedAt: null,
+        isArchived: false,
+        moderationStatus: 'APPROVED',
+        AND: [
+          memoryVisibilityFilter,
+          {
+            OR: [
+              { title: searchFilter },
+              { description: searchFilter },
+              { tags: { some: { name: searchFilter } } },
+              { location: { buildingName: searchFilter } },
+            ],
+          },
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        mediaURL: true,
+        memoryDate: true,
+        createdAt: true,
+        creator: { select: { firstName: true, lastName: true } },
+        location: { select: { id: true, buildingName: true } },
+        tags: { select: { id: true, name: true, slug: true } },
+        programBatch: {
+          select: {
+            program: { select: { name: true } },
+            batch: { select: { year: true } },
+          },
+        },
+      },
+      skip,
+      take: limit,
+      // Order by chronological batch order (if applicable) or created date
+      orderBy: [
+        { programBatch: { batch: { year: 'desc' } } },
+        { memoryDate: 'desc' },
+        { createdAt: 'desc' },
+      ],
+    }),
+
+    // LOCATIONS
+    prisma.location.findMany({
+      where: {
+        OR: [{ buildingName: searchFilter }, { description: searchFilter }],
+      },
+      select: {
+        id: true,
+        buildingName: true,
+        description: true,
+        latitude: true,
+        longitude: true,
+        _count: { select: { memories: true } },
+      },
+      skip,
+      take: limit,
+      orderBy: { buildingName: 'asc' },
+    }),
+
+    // TAGS
+    prisma.tag.findMany({
+      where: {
+        name: searchFilter,
+      },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        _count: { select: { memories: true } },
+      },
+      skip,
+      take: limit,
+      orderBy: { memories: { _count: 'desc' } },
+    }),
+
+    // BATCHES / PROGRAMS
+    prisma.programBatch.findMany({
+      where: {
+        OR: [
+          { program: { name: searchFilter } },
+          { batch: { year: { equals: parseInt(query) || 0 } } },
+        ],
+      },
+      select: {
+        id: true,
+        program: { select: { name: true } },
+        batch: { select: { year: true } },
+      },
+      skip,
+      take: limit,
+      orderBy: { batch: { year: 'desc' } },
+    }),
+  ]);
+
+  return {
+    users,
+    memories,
+    locations,
+    tags,
+    batches,
+  };
+}

--- a/src/services/update-memory-service.ts
+++ b/src/services/update-memory-service.ts
@@ -1,0 +1,104 @@
+import { prisma } from '@/lib/prisma';
+import { slugify } from '@/lib/slugify';
+import { MAX_TAGS, type EditMemoryInput } from '@/lib/schemas';
+import { generateAutoTags } from '@/lib/utils/memory-tags';
+import { assertCanPostInGroup } from '@/lib/group-permissions';
+
+interface UpdateMemoryInput {
+  memoryId: string;
+  actorId: string;
+  isAdmin: boolean;
+  data: EditMemoryInput;
+}
+
+export async function updateMemoryService(
+  input: UpdateMemoryInput
+): Promise<{ id: string }> {
+  const { memoryId, actorId, isAdmin, data } = input;
+
+  const memory = await prisma.memory.findUnique({
+    where: { id: memoryId, deletedAt: null },
+    select: {
+      id: true,
+      creatorId: true,
+      locationId: true,
+      memoryDate: true,
+      visibility: true,
+      privateGroupId: true,
+    },
+  });
+
+  if (!memory) {
+    throw new Error('Memory not found');
+  }
+
+  const effectiveVisibility = data.visibility ?? memory.visibility;
+  // null means explicitly unset; undefined means not provided (keep existing)
+  const effectivePrivateGroupId =
+    data.privateGroupId !== undefined
+      ? data.privateGroupId
+      : memory.privateGroupId;
+
+  if (effectiveVisibility === 'GROUP_ONLY' && !effectivePrivateGroupId) {
+    throw new Error('Group ID is required for group-only memories');
+  }
+
+  if (
+    !isAdmin &&
+    data.privateGroupId !== undefined &&
+    data.privateGroupId !== null &&
+    data.privateGroupId !== memory.privateGroupId
+  ) {
+    await assertCanPostInGroup(actorId, data.privateGroupId);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updateData: any = {
+    ...(data.title !== undefined && { title: data.title }),
+    ...(data.description !== undefined && { description: data.description }),
+    ...(data.visibility !== undefined && { visibility: data.visibility }),
+    ...(data.privateGroupId !== undefined && {
+      privateGroup:
+        data.privateGroupId === null
+          ? { disconnect: true }
+          : { connect: { id: data.privateGroupId } },
+    }),
+  };
+
+  if (data.tags !== undefined) {
+    const autoTags = await generateAutoTags(
+      memory.locationId,
+      memory.memoryDate ?? undefined
+    );
+
+    const allTagNames = [...autoTags, ...data.tags];
+    const uniqueTags: string[] = [];
+    const seenSlugs = new Set<string>();
+
+    for (const tagName of allTagNames) {
+      const slug = slugify(tagName);
+      if (!seenSlugs.has(slug)) {
+        seenSlugs.add(slug);
+        uniqueTags.push(tagName);
+      }
+    }
+
+    const finalTags = uniqueTags.slice(0, MAX_TAGS);
+
+    updateData.tags = {
+      set: [],
+      connectOrCreate: finalTags.map((tagName) => ({
+        where: { slug: slugify(tagName) },
+        create: { name: tagName, slug: slugify(tagName) },
+      })),
+    };
+  }
+
+  const updated = await prisma.memory.update({
+    where: { id: memoryId },
+    data: updateData,
+    select: { id: true },
+  });
+
+  return updated;
+}

--- a/src/services/update-memory-service.ts
+++ b/src/services/update-memory-service.ts
@@ -2,7 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { slugify } from '@/lib/slugify';
 import { MAX_TAGS, type EditMemoryInput } from '@/lib/schemas';
 import { generateAutoTags } from '@/lib/utils/memory-tags';
-import { assertCanPostInGroup } from '@/lib/group-permissions';
+import { assertCanPostInGroup } from '@/lib/server/group-permissions';
 
 interface UpdateMemoryInput {
   memoryId: string;

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -723,6 +723,35 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/prisma/memory/{memoryId}/edit:
+    patch:
+      tags: [Memories]
+      summary: Edit memory
+      operationId: editMemory
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/memoryId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditMemoryInput'
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/prisma/memory/vote/toggle:
     post:
       tags: [Votes]
@@ -1289,6 +1318,31 @@ components:
         mediaURL:
           type: string
           format: uri
+
+    EditMemoryInput:
+      type: object
+      minProperties: 1
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          maxLength: 5000
+        visibility:
+          $ref: '#/components/schemas/MemoryVisibility'
+        tags:
+          type: array
+          maxItems: 10
+          items:
+            type: string
+            minLength: 1
+            maxLength: 50
+        privateGroupId:
+          type: string
+          format: uuid
+          nullable: true
 
     UpdateMemoryTagsInput:
       type: object

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -25,6 +25,46 @@ tags:
   - name: Storage
 
 paths:
+  /api/prisma/search:
+    get:
+      tags: [Search]
+      summary: Global search across memories, users, locations, tags, and groups
+      operationId: globalSearch
+      security:
+        - SupabaseSession: []
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+          description: Search term query
+        - in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            default: 1
+          description: Page number for pagination
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            default: 20
+          description: Number of results per category
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/prisma/user/create:
     post:
       tags: [Users]


### PR DESCRIPTION
## Summary

Establishes the backend infrastructure and service layer for the global search feature, enabling full-text search across memories, users, locations, tags, and batches with strict privacy border enforcement.

- **Zod schemas** added to `schemas.ts` — `searchQuerySchema` strictly validates the query string (`q`) and safely coerces pagination limits (`page`, `limit`) on the server.
- **Service layer** created in `search-service.ts` — `searchService` fetches concurrently across 5 Prisma models (`User`, `Memory`, `Location`, `Tag`, `ProgramBatch`) using `Promise.all` and `contains: 'insensitive'` for soft text matching.
- **Visibility rules enforced** — The service dynamically builds a `memoryVisibilityFilter` utilizing the authenticated actor's `programBatch` and `groupMemberships`. Ensures `GROUP_ONLY`, `PRIVATE`, `PROGRAM_ONLY`, and `BATCH_ONLY` memories never leak to unauthorized users in search results.
- **API route** added at `GET /api/prisma/search` — fully standardizes the network layer. Extracts query parameters, validates Supabase authentication, calls the service layer, and returns a cleanly structured `{ success, data }` response.
- **Swagger documentation** updated in `swagger.yaml` — formally documents the endpoint, required query parameters, and expected HTTP response codes for contract-first development.

### What's intentionally deferred

- Frontend integration (the `useSearch` hook and Global Search Bar UI component are left for a follow-up frontend ticket).
- PostgreSQL native full-text search indexing (`tsvector` / `pg_trgm`). We are currently using Prisma's string `contains` filtering as a functional soft-search until raw SQL text indexes are introduced in a future database optimization phase.

### Relation to prior work

This directly addresses the missing global search API flagged in the `PRE_BETA_AUDIT_REPORT.md`. It strictly follows the atomic, service-oriented architecture pattern established in recent backend PRs (such as the `SCRUM-110` memory-edit branch), ensuring that business logic and database queries are kept entirely out of the Next.js API route handlers.