### PR TITLE
GROUP-2: Group edit UI modal

### DIFF
--- a/src/app/api/prisma/group/[groupId]/route.ts
+++ b/src/app/api/prisma/group/[groupId]/route.ts
@@ -106,8 +106,9 @@ export async function GET(
 /**
  * PATCH /api/prisma/group/[groupId]
  *
- * Updates a group's name, description, or message. Only the group creator
- * (owner) is allowed to perform this action.
+ * Updates a group's name, description, or message.
+ * OWNER: can update name, description, message.
+ * ADMIN: can update message only.
  */
 export async function PATCH(
   request: NextRequest,
@@ -149,15 +150,32 @@ export async function PATCH(
       group.groupMemberships[0]?.role
     );
 
-    if (currentUserRole !== 'OWNER') {
+    const body = await request.json();
+
+    if (currentUserRole !== 'OWNER' && currentUserRole !== 'ADMIN') {
       return NextResponse.json(
-        { error: 'Only the group owner can update settings' },
+        { error: 'Only group owners or admins can update settings' },
         { status: 403 }
       );
     }
 
+    // ADMINs may only update the message field.
+    if (currentUserRole === 'ADMIN') {
+      const bodyKeys = Object.keys(body ?? {}).filter(
+        (k) => body[k] !== undefined
+      );
+      const forbidden = bodyKeys.filter(
+        (k) => k === 'name' || k === 'description'
+      );
+      if (forbidden.length > 0) {
+        return NextResponse.json(
+          { error: 'Only the group owner can update name or description' },
+          { status: 403 }
+        );
+      }
+    }
+
     // ── 3. Validate body ─────────────────────────────────────────────
-    const body = await request.json();
     const parsed = updateGroupServerSchema.safeParse(body);
 
     if (!parsed.success) {

--- a/src/components/groups/EditGroupMessageModal.tsx
+++ b/src/components/groups/EditGroupMessageModal.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Loader2, MessageSquare } from 'lucide-react';
+import { useUpdateGroup } from '@/lib/hooks/useUpdateGroup';
+import { updateGroupServerSchema } from '@/lib/schemas';
+import { WOBBLY_RADIUS, WOBBLY_RADIUS_MD } from '@/lib/hand-drawn';
+import { type Group } from '@/lib/types/group';
+
+interface EditGroupMessageModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  group: Group;
+  onUpdated: () => void;
+}
+
+export function EditGroupMessageModal({
+  open,
+  onOpenChange,
+  group,
+  onUpdated,
+}: EditGroupMessageModalProps) {
+  const [message, setMessage] = useState(group.message ?? '');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const updateGroup = useUpdateGroup();
+
+  useEffect(() => {
+    if (open) {
+      setMessage(group.message ?? '');
+      setErrors({});
+    }
+  }, [open, group]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleSubmit = () => {
+    const payload = { message: message.trim() };
+
+    const parsed = updateGroupServerSchema.safeParse(payload);
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const key = issue.path[0]?.toString() ?? 'root';
+        fieldErrors[key] = issue.message;
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+
+    if (parsed.data.message === (group.message ?? '')) {
+      handleClose();
+      return;
+    }
+
+    updateGroup.mutate(
+      { groupId: group.id, data: parsed.data },
+      {
+        onSuccess: () => {
+          onUpdated();
+          handleClose();
+        },
+        onError: (err) => {
+          setErrors({ root: err.message });
+        },
+      }
+    );
+  };
+
+  const isSaving = updateGroup.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={(val) => !val && handleClose()}>
+      <DialogContent
+        className="flex max-w-md flex-col gap-0 overflow-hidden p-0"
+        showCloseButton={false}
+        style={{ borderRadius: WOBBLY_RADIUS_MD }}
+      >
+        <DialogTitle className="sr-only">Edit Group Message</DialogTitle>
+
+        <div className="flex items-center gap-2 border-b border-border px-6 py-4">
+          <MessageSquare className="h-4 w-4 text-muted-foreground" />
+          <h2 className="font-kalam text-base font-semibold text-foreground">
+            Group Message
+          </h2>
+        </div>
+
+        <div className="flex-1 space-y-4 overflow-y-auto p-6">
+          <p className="font-hand text-sm text-muted-foreground">
+            This message is pinned for all group members. Keep it short and
+            relevant.
+          </p>
+
+          {errors.root && (
+            <p className="font-hand text-sm text-destructive">{errors.root}</p>
+          )}
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="edit-group-message"
+              className="font-hand text-sm font-medium"
+            >
+              Message
+            </Label>
+            <textarea
+              id="edit-group-message"
+              value={message}
+              onChange={(e) => {
+                setMessage(e.target.value);
+                setErrors((prev) => ({ ...prev, message: '' }));
+              }}
+              maxLength={300}
+              rows={4}
+              placeholder="Write a message for your group members..."
+              className={`w-full resize-none rounded border border-border bg-background px-3 py-2 font-hand text-sm text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring ${errors.message ? 'border-destructive focus:ring-destructive/20' : ''}`}
+              style={{ borderRadius: WOBBLY_RADIUS }}
+            />
+            <div className="flex items-center justify-between">
+              {errors.message ? (
+                <p className="font-hand text-xs text-destructive">
+                  {errors.message}
+                </p>
+              ) : (
+                <span />
+              )}
+              <span className="font-hand text-xs text-muted-foreground">
+                {message.length}/300
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 border-t border-border bg-card px-6 py-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClose}
+            disabled={isSaving}
+            className="font-hand"
+            style={{ borderRadius: WOBBLY_RADIUS }}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={isSaving}
+            className="font-hand"
+            style={{ borderRadius: WOBBLY_RADIUS }}
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Message'
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/EditGroupModal.tsx
+++ b/src/components/groups/EditGroupModal.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2, Pencil } from 'lucide-react';
+import { useUpdateGroup } from '@/lib/hooks/useUpdateGroup';
+import { updateGroupServerSchema } from '@/lib/schemas';
+import { WOBBLY_RADIUS, WOBBLY_RADIUS_MD } from '@/lib/hand-drawn';
+import { type Group } from '@/lib/types/group';
+
+interface EditGroupModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  group: Group;
+  onUpdated: () => void;
+}
+
+export function EditGroupModal({
+  open,
+  onOpenChange,
+  group,
+  onUpdated,
+}: EditGroupModalProps) {
+  const [name, setName] = useState(group.name);
+  const [description, setDescription] = useState(group.description ?? '');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const updateGroup = useUpdateGroup();
+
+  useEffect(() => {
+    if (open) {
+      setName(group.name);
+      setDescription(group.description ?? '');
+      setErrors({});
+    }
+  }, [open, group]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleSubmit = () => {
+    const payload = {
+      name: name.trim() || undefined,
+      description: description.trim(),
+    };
+
+    const parsed = updateGroupServerSchema.safeParse(payload);
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const key = issue.path[0]?.toString() ?? 'root';
+        fieldErrors[key] = issue.message;
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+
+    if (
+      parsed.data.name === group.name &&
+      (parsed.data.description ?? '') === (group.description ?? '')
+    ) {
+      handleClose();
+      return;
+    }
+
+    updateGroup.mutate(
+      { groupId: group.id, data: parsed.data },
+      {
+        onSuccess: () => {
+          onUpdated();
+          handleClose();
+        },
+        onError: (err) => {
+          setErrors({ root: err.message });
+        },
+      }
+    );
+  };
+
+  const isSaving = updateGroup.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={(val) => !val && handleClose()}>
+      <DialogContent
+        className="flex max-w-md flex-col gap-0 overflow-hidden p-0"
+        showCloseButton={false}
+        style={{ borderRadius: WOBBLY_RADIUS_MD }}
+      >
+        <DialogTitle className="sr-only">Edit Group</DialogTitle>
+
+        <div className="flex items-center gap-2 border-b border-border px-6 py-4">
+          <Pencil className="h-4 w-4 text-muted-foreground" />
+          <h2 className="font-kalam text-base font-semibold text-foreground">
+            Edit Group
+          </h2>
+        </div>
+
+        <div className="flex-1 space-y-5 overflow-y-auto p-6">
+          {errors.root && (
+            <p className="font-hand text-sm text-destructive">{errors.root}</p>
+          )}
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="edit-group-name"
+              className="font-hand text-sm font-medium"
+            >
+              Group Name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="edit-group-name"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setErrors((prev) => ({ ...prev, name: '' }));
+              }}
+              maxLength={50}
+              placeholder="Enter group name"
+              className={`font-hand ${errors.name ? 'border-destructive focus-visible:ring-destructive/20' : ''}`}
+              style={{ borderRadius: WOBBLY_RADIUS }}
+            />
+            <div className="flex items-center justify-between">
+              {errors.name ? (
+                <p className="font-hand text-xs text-destructive">
+                  {errors.name}
+                </p>
+              ) : (
+                <span />
+              )}
+              <span className="font-hand text-xs text-muted-foreground">
+                {name.length}/50
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="edit-group-description"
+              className="font-hand text-sm font-medium"
+            >
+              Description
+            </Label>
+            <textarea
+              id="edit-group-description"
+              value={description}
+              onChange={(e) => {
+                setDescription(e.target.value);
+                setErrors((prev) => ({ ...prev, description: '' }));
+              }}
+              maxLength={500}
+              rows={3}
+              placeholder="What is this group about?"
+              className={`w-full resize-none rounded border border-border bg-background px-3 py-2 font-hand text-sm text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring ${errors.description ? 'border-destructive focus:ring-destructive/20' : ''}`}
+              style={{ borderRadius: WOBBLY_RADIUS }}
+            />
+            <div className="flex items-center justify-between">
+              {errors.description ? (
+                <p className="font-hand text-xs text-destructive">
+                  {errors.description}
+                </p>
+              ) : (
+                <span />
+              )}
+              <span className="font-hand text-xs text-muted-foreground">
+                {description.length}/500
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 border-t border-border bg-card px-6 py-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClose}
+            disabled={isSaving}
+            className="font-hand"
+            style={{ borderRadius: WOBBLY_RADIUS }}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={isSaving || !name.trim()}
+            className="font-hand"
+            style={{ borderRadius: WOBBLY_RADIUS }}
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Changes'
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -8,6 +8,8 @@ import { InviteMembersModal } from '@/components/groups/InviteMembersModal';
 import { ShareGroupModal } from '@/components/groups/ShareGroupModal';
 import { LeaveGroupModal } from '@/components/groups/LeaveGroupModal';
 import { DeleteGroupModal } from '@/components/groups/DeleteGroupModal';
+import { EditGroupModal } from '@/components/groups/EditGroupModal';
+import { EditGroupMessageModal } from '@/components/groups/EditGroupMessageModal';
 import { MembersTab } from '@/components/groups/tabs/MembersTab';
 import { MediaTab } from '@/components/groups/tabs/MediaTab';
 import { AboutTab } from '@/components/groups/tabs/AboutTab';
@@ -44,6 +46,8 @@ import {
   Lock,
   Loader2,
   Shield,
+  Pencil,
+  MessageSquare,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -118,6 +122,8 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [leaveModalOpen, setLeaveModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [editGroupModalOpen, setEditGroupModalOpen] = useState(false);
+  const [editMessageModalOpen, setEditMessageModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType>('members');
 
   const { showSuccess, showError } = useGroupToast();
@@ -171,6 +177,9 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const canSendInvitations =
     !!selectedGroup &&
     canRoleUsePermission(rolePrivileges, currentUserRole, 'sendInvitations');
+  const canEditMessage =
+    !!selectedGroup &&
+    (currentUserRole === 'OWNER' || currentUserRole === 'ADMIN');
 
   // ─── Handlers ────────────────────────────────────────────────────
   const handleSelectGroup = useCallback((group: Group) => {
@@ -262,6 +271,16 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const handlePrivilegesSaved = useCallback(() => {
     refetchGroupDetail();
     showSuccess('Role privileges updated successfully.');
+  }, [refetchGroupDetail, showSuccess]);
+
+  const handleGroupUpdated = useCallback(() => {
+    refetchGroupDetail();
+    showSuccess('Group updated successfully.');
+  }, [refetchGroupDetail, showSuccess]);
+
+  const handleMessageUpdated = useCallback(() => {
+    refetchGroupDetail();
+    showSuccess('Group message updated.');
   }, [refetchGroupDetail, showSuccess]);
 
   return (
@@ -416,6 +435,17 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-48">
+                        {isOwner && (
+                          <>
+                            <DropdownMenuItem
+                              onClick={() => setEditGroupModalOpen(true)}
+                            >
+                              <Pencil className="mr-2 h-4 w-4" />
+                              Edit Group
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                          </>
+                        )}
                         {canSendInvitations && (
                           <>
                             <DropdownMenuItem
@@ -434,6 +464,17 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
                           Share Group
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
+                        {canEditMessage && (
+                          <>
+                            <DropdownMenuItem
+                              onClick={() => setEditMessageModalOpen(true)}
+                            >
+                              <MessageSquare className="mr-2 h-4 w-4" />
+                              Edit Message
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                          </>
+                        )}
                         <DropdownMenuItem
                           onClick={() => setLeaveModalOpen(true)}
                           className="text-red-600 focus:text-red-600"
@@ -558,6 +599,24 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
             groupName={selectedGroup.name}
             onConfirmDelete={handleGroupDeleted}
           />
+
+          {isOwner && (
+            <EditGroupModal
+              open={editGroupModalOpen}
+              onOpenChange={setEditGroupModalOpen}
+              group={selectedGroup}
+              onUpdated={handleGroupUpdated}
+            />
+          )}
+
+          {canEditMessage && (
+            <EditGroupMessageModal
+              open={editMessageModalOpen}
+              onOpenChange={setEditMessageModalOpen}
+              group={selectedGroup}
+              onUpdated={handleMessageUpdated}
+            />
+          )}
         </>
       )}
     </>

--- a/src/components/groups/index.ts
+++ b/src/components/groups/index.ts
@@ -2,6 +2,8 @@ export * from './GroupPanel';
 export * from './GroupSwitcher';
 export * from './GroupDetailView';
 export * from './CreateGroupModal';
+export * from './EditGroupModal';
+export * from './EditGroupMessageModal';
 export * from './DeleteGroupModal';
 export * from './InviteMembersModal';
 export * from './ShareGroupModal';


### PR DESCRIPTION
1. Added a dedicated owner-only modal workflow to update group name and description through header actions with schema-based validation and no-op request prevention.
2. Extended group settings patch authorization to allow admins to update message while enforcing owner-only control for name and description with explicit forbidden-field checks.
3. Added a dedicated message edit modal for owner and admin roles with inline validation, character counting, and optimistic close behavior on unchanged data.
4. Wired new modal actions into group panel dropdown flow with strict role gating to keep controls aligned with permission semantics.
5. Added refresh and success feedback handlers after mutation completion to keep panel state, detail cache, and visible group data synchronized.