### PR TITLE
Scrum 111 memory 2 memory edit UI modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ plans/
 
 # test-results
 test-results/
+.github/prompts/MEMORY-2_edit-modal.md

--- a/src/components/add-memory-modal.tsx
+++ b/src/components/add-memory-modal.tsx
@@ -7,6 +7,7 @@ import { useCreateMemory } from '@/lib/hooks/useCreateMemory';
 import { useCreateCustomLocation } from '@/lib/hooks/useCreateCustomLocation';
 import { useLocations } from '@/lib/hooks/useLocations';
 import { useCurrentUser } from '@/lib/hooks/useCurrentUser';
+import { useUserGroups } from '@/lib/hooks/useUserGroups';
 import {
   MAX_TAGS,
   VISIBILITY_LABELS,
@@ -95,6 +96,7 @@ const VISIBILITY_OPTIONS: {
   label: string;
   description: string;
   icon: typeof Globe;
+  requiresGroup?: boolean;
 }[] = [
   {
     value: 'PUBLIC',
@@ -115,16 +117,11 @@ const VISIBILITY_OPTIONS: {
     icon: Shield,
   },
   {
-    value: 'PRIVATE',
-    label: VISIBILITY_LABELS.PRIVATE,
-    description: 'Only you can see this',
-    icon: Lock,
-  },
-  {
     value: 'GROUP_ONLY',
-    label: 'Group Only',
-    description: 'Visible to group members only',
-    icon: Users,
+    label: 'Private',
+    description: 'Visible to selected group only',
+    icon: Lock,
+    requiresGroup: true,
   },
 ];
 
@@ -249,6 +246,13 @@ export function AddMemoryModal({
 
   const programBatch = currentUserData?.data?.programBatch ?? null;
 
+  const { data: userGroups, isLoading: isLoadingGroups } = useUserGroups();
+  const hasGroups = (userGroups?.length ?? 0) > 0;
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
+    defaultGroupId ?? null
+  );
+  const [showGroupDropdown, setShowGroupDropdown] = useState(false);
+
   const batchLabel = useMemo(() => {
     if (!programBatch) return null;
     return `${programBatch.program.name} • Batch ${programBatch.batch.year}`;
@@ -333,6 +337,8 @@ export function AddMemoryModal({
     setSelectedLocationId(null);
     setSearchQuery('');
     setIsCreatingLocation(false);
+    setSelectedGroupId(defaultGroupId ?? null);
+    setShowGroupDropdown(false);
   }, [defaultGroupId]);
 
   // ---------------------------------------------------------------------------
@@ -536,8 +542,8 @@ export function AddMemoryModal({
 
     const locationId = selectedLocationId ?? locations[0]?.id ?? '';
 
-    if (visibility === 'GROUP_ONLY' && !defaultGroupId) {
-      setSubmitError('GROUP_ONLY visibility requires opening from a group');
+    if (visibility === 'GROUP_ONLY' && !selectedGroupId) {
+      setSubmitError('Please select a group for private visibility');
       return;
     }
 
@@ -550,8 +556,8 @@ export function AddMemoryModal({
         memoryDate: memoryDate ? new Date(memoryDate) : undefined,
         tags,
         mediaFile: firstCompleted?.file,
-        ...(visibility === 'GROUP_ONLY' && defaultGroupId
-          ? { privateGroupId: defaultGroupId }
+        ...(visibility === 'GROUP_ONLY' && selectedGroupId
+          ? { privateGroupId: selectedGroupId }
           : {}),
       },
       {
@@ -580,7 +586,7 @@ export function AddMemoryModal({
     createMemory,
     resetState,
     onOpenChange,
-    defaultGroupId,
+    selectedGroupId,
   ]);
 
   // ---------------------------------------------------------------------------
@@ -1151,14 +1157,83 @@ export function AddMemoryModal({
           <button
             type="button"
             onClick={() => {
-              // TODO: Implement set privacy
-              console.log('[AddMemoryModal] set privacy clicked');
+              // Cycle through visibility options
+              const currentIndex = VISIBILITY_OPTIONS.findIndex(
+                (o) => o.value === visibility
+              );
+              const nextIndex = (currentIndex + 1) % VISIBILITY_OPTIONS.length;
+              const nextOption = VISIBILITY_OPTIONS[nextIndex];
+              // Skip GROUP_ONLY if user has no groups
+              if (nextOption.requiresGroup && !hasGroups) {
+                setVisibility(VISIBILITY_OPTIONS[0].value);
+              } else {
+                setVisibility(nextOption.value);
+              }
+              if (nextOption.value !== 'GROUP_ONLY') {
+                setSelectedGroupId(null);
+              }
             }}
             className="text-sm font-medium text-skolaroid-blue hover:underline"
           >
             Set privacy
           </button>
         </div>
+
+        {/* Group selector (shown when Private/GROUP_ONLY is selected) */}
+        {visibility === 'GROUP_ONLY' && (
+          <div className="flex items-start gap-3 pl-8">
+            <div className="relative w-full">
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Select Group
+              </label>
+              <button
+                type="button"
+                onClick={() => setShowGroupDropdown(!showGroupDropdown)}
+                disabled={isLoadingGroups}
+                className="flex w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm"
+              >
+                <span>
+                  {isLoadingGroups
+                    ? 'Loading groups...'
+                    : (userGroups?.find((g) => g.id === selectedGroupId)
+                        ?.name ?? 'Choose a group...')}
+                </span>
+                <Users className="h-4 w-4 text-muted-foreground" />
+              </button>
+              {showGroupDropdown && userGroups && (
+                <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-40 overflow-y-auto rounded-md border border-border bg-card shadow-md">
+                  {userGroups.length === 0 ? (
+                    <p className="px-3 py-3 text-center text-sm text-muted-foreground">
+                      No groups available. Create a group first.
+                    </p>
+                  ) : (
+                    userGroups.map((group) => (
+                      <button
+                        key={group.id}
+                        type="button"
+                        onClick={() => {
+                          setSelectedGroupId(group.id);
+                          setShowGroupDropdown(false);
+                        }}
+                        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                          selectedGroupId === group.id
+                            ? 'bg-blue-50 text-skolaroid-blue'
+                            : 'hover:bg-secondary'
+                        }`}
+                      >
+                        <span className="flex-1 truncate">{group.name}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {group._count.members} member
+                          {group._count.members !== 1 ? 's' : ''}
+                        </span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* Submit error */}
         {submitError && (

--- a/src/components/map/EditMemoryModal.tsx
+++ b/src/components/map/EditMemoryModal.tsx
@@ -1,0 +1,402 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Globe,
+  GraduationCap,
+  Users,
+  Lock,
+  ChevronDown,
+  Loader2,
+  Info,
+} from 'lucide-react';
+import { useUpdateMemory } from '@/lib/hooks/useUpdateMemory';
+import { useUserGroups } from '@/lib/hooks/useUserGroups';
+import type { MemoryVisibility } from '@/lib/schemas';
+import type { MemoryWithCoordinates } from '@/lib/hooks/useAllMemoriesWithCoordinates';
+import { WOBBLY_RADIUS_MD } from '@/lib/hand-drawn';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EDIT_VISIBILITY_OPTIONS: {
+  value: MemoryVisibility;
+  label: string;
+  description: string;
+  icon: typeof Globe;
+}[] = [
+  {
+    value: 'PUBLIC',
+    label: 'Public',
+    description: 'Everyone can see this memory',
+    icon: Globe,
+  },
+  {
+    value: 'PROGRAM_ONLY',
+    label: 'Program Only',
+    description: 'Visible to your program',
+    icon: GraduationCap,
+  },
+  {
+    value: 'BATCH_ONLY',
+    label: 'Batch Only',
+    description: 'Visible to your batch',
+    icon: Users,
+  },
+  {
+    value: 'GROUP_ONLY',
+    label: 'Private',
+    description: 'Visible to selected group only',
+    icon: Lock,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface EditMemoryModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  memory: MemoryWithCoordinates;
+  onMemoryUpdated?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function EditMemoryModal({
+  open,
+  onOpenChange,
+  memory,
+  onMemoryUpdated,
+}: EditMemoryModalProps) {
+  // ── State ──────────────────────────────────────────────────────────────
+  const [description, setDescription] = useState(memory.description ?? '');
+  const [visibility, setVisibility] = useState<MemoryVisibility>(
+    memory.visibility
+  );
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
+    memory.privateGroupId ?? null
+  );
+  const [showVisibilityDropdown, setShowVisibilityDropdown] = useState(false);
+  const [showGroupDropdown, setShowGroupDropdown] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const visibilityRef = useRef<HTMLDivElement>(null);
+  const groupRef = useRef<HTMLDivElement>(null);
+
+  // ── Hooks ──────────────────────────────────────────────────────────────
+  const updateMemory = useUpdateMemory();
+  const { data: userGroups, isLoading: isLoadingGroups } = useUserGroups();
+  const hasGroups = (userGroups?.length ?? 0) > 0;
+
+  // ── Sync state when memory changes or modal opens ─────────────────────
+  useEffect(() => {
+    if (open) {
+      setDescription(memory.description ?? '');
+      setVisibility(memory.visibility);
+      setSelectedGroupId(memory.privateGroupId ?? null);
+      setError(null);
+      setShowVisibilityDropdown(false);
+      setShowGroupDropdown(false);
+    }
+  }, [open, memory]);
+
+  // ── Click-outside detection ───────────────────────────────────────────
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        visibilityRef.current &&
+        !visibilityRef.current.contains(e.target as Node)
+      ) {
+        setShowVisibilityDropdown(false);
+      }
+      if (groupRef.current && !groupRef.current.contains(e.target as Node)) {
+        setShowGroupDropdown(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // ── Derived ───────────────────────────────────────────────────────────
+  const currentOption =
+    EDIT_VISIBILITY_OPTIONS.find((o) => o.value === visibility) ??
+    EDIT_VISIBILITY_OPTIONS[0];
+  const CurrentIcon = currentOption.icon;
+
+  const selectedGroup = userGroups?.find((g) => g.id === selectedGroupId);
+
+  // ── Handlers ──────────────────────────────────────────────────────────
+  const handleVisibilitySelect = (value: MemoryVisibility) => {
+    setVisibility(value);
+    setShowVisibilityDropdown(false);
+    setError(null);
+
+    // Reset group when switching away from GROUP_ONLY
+    if (value !== 'GROUP_ONLY') {
+      setSelectedGroupId(null);
+    }
+  };
+
+  const handleGroupSelect = (groupId: string) => {
+    setSelectedGroupId(groupId);
+    setShowGroupDropdown(false);
+    setError(null);
+  };
+
+  const handleSave = () => {
+    if (visibility === 'GROUP_ONLY' && !selectedGroupId) {
+      setError('Please select a group for private visibility');
+      return;
+    }
+
+    updateMemory.mutate(
+      {
+        memoryId: memory.id,
+        description: description.trim() || undefined,
+        visibility,
+        privateGroupId: visibility === 'GROUP_ONLY' ? selectedGroupId : null,
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          onMemoryUpdated?.();
+        },
+        onError: (err) => {
+          setError(
+            err instanceof Error ? err.message : 'Failed to update memory'
+          );
+        },
+      }
+    );
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="border-2 shadow-[6px_6px_0px_0px_#2d2d2d] sm:max-w-md"
+        style={{ borderRadius: WOBBLY_RADIUS_MD }}
+      >
+        <DialogHeader>
+          <DialogTitle className="font-kalam text-xl">Edit Memory</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          {/* Description */}
+          <div>
+            <label
+              htmlFor="edit-description"
+              className="mb-1.5 block font-hand text-sm font-medium text-foreground"
+            >
+              Description
+            </label>
+            <textarea
+              id="edit-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={5000}
+              placeholder="Describe this memory..."
+              className="min-h-[100px] w-full border-2 border-border bg-card px-3 py-2 font-hand text-sm text-foreground placeholder:text-muted-foreground focus:border-skolaroid-blue focus:outline-none focus:ring-1 focus:ring-skolaroid-blue"
+              style={{ borderRadius: WOBBLY_RADIUS_MD }}
+            />
+          </div>
+
+          {/* Visibility dropdown */}
+          <div>
+            <label className="mb-1.5 block font-hand text-sm font-medium text-foreground">
+              Visibility
+            </label>
+            <div ref={visibilityRef} className="relative">
+              <button
+                type="button"
+                onClick={() =>
+                  setShowVisibilityDropdown(!showVisibilityDropdown)
+                }
+                className={cn(
+                  'flex w-full items-center justify-between border-2 border-border bg-card px-3 py-2.5 font-hand text-sm transition-colors',
+                  showVisibilityDropdown &&
+                    'border-skolaroid-blue ring-1 ring-skolaroid-blue'
+                )}
+                style={{ borderRadius: WOBBLY_RADIUS_MD }}
+              >
+                <span className="flex items-center gap-2">
+                  <CurrentIcon className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-foreground">{currentOption.label}</span>
+                </span>
+                <ChevronDown
+                  className={cn(
+                    'h-4 w-4 text-muted-foreground transition-transform',
+                    showVisibilityDropdown && 'rotate-180'
+                  )}
+                />
+              </button>
+
+              {showVisibilityDropdown && (
+                <div
+                  className="absolute left-0 right-0 top-full z-50 mt-1 overflow-hidden border-2 border-border bg-card shadow-[4px_4px_0px_0px_#2d2d2d]"
+                  style={{ borderRadius: WOBBLY_RADIUS_MD }}
+                >
+                  {EDIT_VISIBILITY_OPTIONS.map((option) => {
+                    const Icon = option.icon;
+                    const isDisabled =
+                      option.value === 'GROUP_ONLY' && !hasGroups;
+                    const isSelected = option.value === visibility;
+
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        disabled={isDisabled}
+                        onClick={() => handleVisibilitySelect(option.value)}
+                        className={cn(
+                          'flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors',
+                          isSelected && 'bg-blue-50',
+                          !isDisabled && !isSelected && 'hover:bg-secondary',
+                          isDisabled && 'cursor-not-allowed opacity-50'
+                        )}
+                      >
+                        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0 flex-1">
+                          <p className="font-hand text-sm font-medium text-foreground">
+                            {option.label}
+                          </p>
+                          <p className="font-hand text-xs text-muted-foreground">
+                            {option.description}
+                          </p>
+                        </div>
+                        {isDisabled && (
+                          <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Group selector (shown when Private/GROUP_ONLY is selected) */}
+          {visibility === 'GROUP_ONLY' && (
+            <div>
+              <label className="mb-1.5 block font-hand text-sm font-medium text-foreground">
+                Select Group
+              </label>
+              <div ref={groupRef} className="relative">
+                <button
+                  type="button"
+                  onClick={() => setShowGroupDropdown(!showGroupDropdown)}
+                  disabled={isLoadingGroups}
+                  className={cn(
+                    'flex w-full items-center justify-between border-2 border-border bg-card px-3 py-2.5 font-hand text-sm transition-colors',
+                    showGroupDropdown &&
+                      'border-skolaroid-blue ring-1 ring-skolaroid-blue'
+                  )}
+                  style={{ borderRadius: WOBBLY_RADIUS_MD }}
+                >
+                  <span className="text-foreground">
+                    {isLoadingGroups
+                      ? 'Loading groups...'
+                      : selectedGroup
+                        ? selectedGroup.name
+                        : 'Choose a group...'}
+                  </span>
+                  <ChevronDown
+                    className={cn(
+                      'h-4 w-4 text-muted-foreground transition-transform',
+                      showGroupDropdown && 'rotate-180'
+                    )}
+                  />
+                </button>
+
+                {showGroupDropdown && userGroups && (
+                  <div
+                    className="absolute left-0 right-0 top-full z-50 mt-1 max-h-48 overflow-y-auto border-2 border-border bg-card shadow-[4px_4px_0px_0px_#2d2d2d]"
+                    style={{ borderRadius: WOBBLY_RADIUS_MD }}
+                  >
+                    {userGroups.length === 0 ? (
+                      <p className="px-3 py-3 text-center font-hand text-sm text-muted-foreground">
+                        No groups available
+                      </p>
+                    ) : (
+                      userGroups.map((group) => (
+                        <button
+                          key={group.id}
+                          type="button"
+                          onClick={() => handleGroupSelect(group.id)}
+                          className={cn(
+                            'flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors',
+                            selectedGroupId === group.id
+                              ? 'bg-blue-50'
+                              : 'hover:bg-secondary'
+                          )}
+                        >
+                          <Users className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate font-hand text-sm font-medium text-foreground">
+                              {group.name}
+                            </p>
+                            <p className="font-hand text-xs text-muted-foreground">
+                              {group._count.members} member
+                              {group._count.members !== 1 ? 's' : ''}
+                            </p>
+                          </div>
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Error message */}
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
+              <p className="font-hand text-sm text-red-600">{error}</p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateMemory.isPending}
+            className="border-2 font-hand"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={updateMemory.isPending}
+            className="border-2 bg-skolaroid-blue font-hand text-white shadow-[3px_3px_0px_0px_#2d2d2d] hover:bg-skolaroid-blue/90"
+          >
+            {updateMemory.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Changes'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/map/MemoryDetailModal.tsx
+++ b/src/components/map/MemoryDetailModal.tsx
@@ -3,11 +3,15 @@
 import {
   MoreHorizontal,
   Globe,
+  GraduationCap,
+  Users,
+  Lock,
   ChevronLeft,
   ChevronRight,
   X,
   Trash2,
   Flag,
+  Pencil,
 } from 'lucide-react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -22,6 +26,7 @@ import {
 import type { MemoryWithCoordinates } from '@/lib/hooks/useAllMemoriesWithCoordinates';
 import { ActionBar } from '@/components/map/ActionBar';
 import { DeleteMemoryModal } from '@/components/map/DeleteMemoryModal';
+import { EditMemoryModal } from '@/components/map/EditMemoryModal';
 import { ReportMemoryModal } from '@/components/map/ReportMemoryModal';
 import { useDeleteMemory } from '@/lib/hooks/useDeleteMemory';
 import { CommentSection } from '@/components/map/CommentSection';
@@ -29,6 +34,8 @@ import { useCommentsByMemory } from '@/lib/hooks/useCommentsByMemory';
 import { useCreateComment } from '@/lib/hooks/useCreateComment';
 import { useDeleteComment } from '@/lib/hooks/useDeleteComment';
 import { useUserAuth } from '@/lib/hooks/useUserAuth';
+import { useUserGroups } from '@/lib/hooks/useUserGroups';
+import type { MemoryVisibility } from '@/lib/schemas';
 import Image from 'next/image';
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -142,6 +149,17 @@ const isAutoTag = (tagName: string): boolean => {
   );
 };
 
+const VISIBILITY_META: Record<
+  MemoryVisibility,
+  { Icon: typeof Globe; label: string }
+> = {
+  PUBLIC: { Icon: Globe, label: 'Public' },
+  PROGRAM_ONLY: { Icon: GraduationCap, label: 'Program Only' },
+  BATCH_ONLY: { Icon: Users, label: 'Batch Only' },
+  GROUP_ONLY: { Icon: Lock, label: 'Private' },
+  PRIVATE: { Icon: Lock, label: 'Private' },
+};
+
 export function MemoryDetailModal({
   memory,
   open,
@@ -154,8 +172,10 @@ export function MemoryDetailModal({
 }: MemoryDetailModalProps) {
   const { user: authUser } = useUserAuth();
   const deleteMemory = useDeleteMemory();
+  const { data: userGroups } = useUserGroups();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [reportModalOpen, setReportModalOpen] = useState(false);
+  const [editModalOpen, setEditModalOpen] = useState(false);
   const isOwner = !!(
     authUser &&
     memory?.creatorId &&
@@ -338,6 +358,22 @@ export function MemoryDetailModal({
     : 'Unknown Author';
   const authorInitial = authorName.charAt(0);
 
+  // Resolve visibility display for a memory (icon + label, with group name for GROUP_ONLY)
+  const getVisibilityDisplay = (
+    vis: MemoryVisibility,
+    pgId?: string | null
+  ) => {
+    const meta = VISIBILITY_META[vis] ?? VISIBILITY_META.PUBLIC;
+    if (vis === 'GROUP_ONLY' && pgId) {
+      const group = userGroups?.find((g) => g.id === pgId);
+      return {
+        Icon: meta.Icon,
+        label: group ? `Private · ${group.name}` : 'Private',
+      };
+    }
+    return meta;
+  };
+
   function handleCommentSubmit(content: string) {
     createComment.mutate({ memoryId: memory!.id, content });
     setCommentText('');
@@ -385,6 +421,16 @@ export function MemoryDetailModal({
                 <div className="fixed inset-0 z-50 flex items-center justify-center">
                   <DialogTitle className="sr-only">{memory.title}</DialogTitle>
 
+                  {/* Close button — fixed to top-right of overlay so it's always visible */}
+                  <button
+                    type="button"
+                    onClick={() => onOpenChange(false)}
+                    className="absolute right-4 top-4 z-30 flex h-10 w-10 items-center justify-center rounded-full border-2 border-border bg-card text-foreground shadow-[3px_3px_0px_0px_#2d2d2d] transition-colors hover:shadow-[4px_4px_0px_0px_#2d2d2d]"
+                    aria-label="Close memory details"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+
                   {/* Wrapper with perspective for 3D */}
                   <div
                     className="flex items-center gap-6"
@@ -414,15 +460,6 @@ export function MemoryDetailModal({
                         transformStyle: 'preserve-3d',
                       }}
                     >
-                      <button
-                        type="button"
-                        onClick={() => onOpenChange(false)}
-                        className="absolute -top-14 right-0 z-30 flex h-10 w-10 items-center justify-center rounded-full border-2 border-border bg-card text-foreground shadow-[3px_3px_0px_0px_#2d2d2d] transition-colors hover:shadow-[4px_4px_0px_0px_#2d2d2d]"
-                        aria-label="Close memory details"
-                      >
-                        <X className="h-5 w-5" />
-                      </button>
-
                       {/* Pages Layer (always visible) */}
                       <div
                         className="absolute inset-0 rounded-2xl bg-sky-200 p-2 shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)]"
@@ -562,8 +599,18 @@ export function MemoryDetailModal({
                                   {authorName}
                                 </p>
                                 <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                                  <Globe className="h-3 w-3" />
-                                  <span>Public</span>
+                                  {(() => {
+                                    const vd = getVisibilityDisplay(
+                                      baseRightMemory.visibility,
+                                      baseRightMemory.privateGroupId
+                                    );
+                                    return (
+                                      <>
+                                        <vd.Icon className="h-3 w-3 shrink-0" />
+                                        <span>{vd.label}</span>
+                                      </>
+                                    );
+                                  })()}
                                 </div>
                               </div>
                               {isOwner ? (
@@ -577,6 +624,12 @@ export function MemoryDetailModal({
                                     </button>
                                   </DropdownMenuTrigger>
                                   <DropdownMenuContent align="end">
+                                    <DropdownMenuItem
+                                      onClick={() => setEditModalOpen(true)}
+                                    >
+                                      <Pencil className="mr-2 h-4 w-4" />
+                                      Edit Memory
+                                    </DropdownMenuItem>
                                     <DropdownMenuItem
                                       className="text-amber-600 focus:text-amber-600"
                                       onClick={() => setReportModalOpen(true)}
@@ -829,8 +882,18 @@ export function MemoryDetailModal({
                                         {authorName}
                                       </p>
                                       <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                                        <Globe className="h-3 w-3" />
-                                        <span>Public</span>
+                                        {(() => {
+                                          const vd = getVisibilityDisplay(
+                                            memory.visibility,
+                                            memory.privateGroupId
+                                          );
+                                          return (
+                                            <>
+                                              <vd.Icon className="h-3 w-3 shrink-0" />
+                                              <span>{vd.label}</span>
+                                            </>
+                                          );
+                                        })()}
                                       </div>
                                     </div>
                                     <button
@@ -907,8 +970,18 @@ export function MemoryDetailModal({
                                       {authorName}
                                     </p>
                                     <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                                      <Globe className="h-3 w-3" />
-                                      <span>Public</span>
+                                      {(() => {
+                                        const vd = getVisibilityDisplay(
+                                          cachedMemory.visibility,
+                                          cachedMemory.privateGroupId
+                                        );
+                                        return (
+                                          <>
+                                            <vd.Icon className="h-3 w-3 shrink-0" />
+                                            <span>{vd.label}</span>
+                                          </>
+                                        );
+                                      })()}
                                     </div>
                                   </div>
                                   <button
@@ -1173,6 +1246,14 @@ export function MemoryDetailModal({
         memoryId={memory?.id ?? ''}
         memoryTitle={memory?.title ?? ''}
       />
+
+      {memory && (
+        <EditMemoryModal
+          open={editModalOpen}
+          onOpenChange={setEditModalOpen}
+          memory={memory}
+        />
+      )}
     </>
   );
 }

--- a/src/lib/hooks/useUpdateMemory.ts
+++ b/src/lib/hooks/useUpdateMemory.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { EditMemoryInput } from '@/lib/schemas';
+
+interface UpdateMemoryPayload extends EditMemoryInput {
+  memoryId: string;
+}
+
+export function useUpdateMemory() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ memoryId, ...data }: UpdateMemoryPayload) => {
+      const res = await fetch(`/api/prisma/memory/${memoryId}/edit`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.message ?? 'Failed to update memory');
+      return body;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['memories'] });
+      queryClient.invalidateQueries({
+        queryKey: ['memory', variables.memoryId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['memories', 'all-with-coordinates'],
+      });
+    },
+  });
+}


### PR DESCRIPTION
- Directive leverages existing edit API at PATCH /api/prisma/memory/[memoryId]/edit which already handles visibility and privateGroupId updates
- EditMemoryModal component spec follows CreateGroupModal.tsx dropdown pattern for consistency
- Visibility mapping: UI "Private" option maps to GROUP_ONLY enum requiring privateGroupId
- useUpdateMemory hook invalidates memories, memory, and memories-with-coordinates query keys on success
- Integration adds edit option to owner dropdown in MemoryDetailModal between report and delete actions
- AddMemoryModal modifications align visibility behavior with edit modal for feature parity