### PR TITLE
feat(map): show first-memory prompt to users with no contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ plans/
 # test-results
 test-results/
 .github/prompts/MEMORY-2_edit-modal.md
+.github/prompts/profile-4-activity-timeline.prompt.md

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -29,6 +29,8 @@ import { MemoryPinStack } from './map/MemoryPinStack';
 import { MemoryDetailModal } from './map/MemoryDetailModal';
 import { useMemoryCountsByLandmark } from '@/lib/hooks/useMemoryCountsByLandmark';
 import { useCurrentUser } from '@/lib/hooks/useCurrentUser';
+import { useMemoriesByCreator } from '@/lib/hooks/useMemoriesByCreator';
+import { MapFirstMemoryPrompt } from './map/MapFirstMemoryPrompt';
 import {
   useAllMemoriesWithCoordinates,
   type MemoryWithCoordinates,
@@ -157,10 +159,19 @@ export function MapComponent({
     useAllMemoriesWithCoordinates();
   const memories = useMemo(() => memoriesData?.data ?? [], [memoriesData]);
   const { data: currentUserData } = useCurrentUser();
+  const currentUserId = currentUserData?.data?.id;
+  const { data: creatorMemoriesData, isLoading: creatorMemoriesLoading } =
+    useMemoriesByCreator(currentUserId);
   const { data: locationsData } = useLocations();
   const { data: userGroupsData } = useUserGroups();
   const userGroups = userGroupsData ?? EMPTY_USER_GROUPS;
   const isAdmin = currentUserData?.data?.role === 'ADMIN';
+
+  const showFirstMemoryPrompt =
+    !!currentUserData?.data &&
+    !creatorMemoriesLoading &&
+    creatorMemoriesData?.data?.length === 0 &&
+    !addMemoryOpen;
 
   const availableGroups = useMemo<GroupFilterOption[]>(
     () =>
@@ -1068,6 +1079,11 @@ export function MapComponent({
         }
         onClose={() => setSelectedLandmark(null)}
       />
+
+      {/* First Memory Prompt — shown to authenticated users with zero memories */}
+      {showFirstMemoryPrompt && (
+        <MapFirstMemoryPrompt onAddMemory={() => setAddMemoryOpen(true)} />
+      )}
 
       {/* Memory Detail Modal */}
       <MemoryDetailModal

--- a/src/components/map/MapFirstMemoryPrompt.tsx
+++ b/src/components/map/MapFirstMemoryPrompt.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, MapPin } from 'lucide-react';
+
+interface MapFirstMemoryPromptProps {
+  onAddMemory: () => void;
+}
+
+export function MapFirstMemoryPrompt({
+  onAddMemory,
+}: MapFirstMemoryPromptProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  return (
+    <AnimatePresence>
+      {!dismissed && (
+        // Wrapper: pointer-events:none so map stays fully interactive behind the card
+        <motion.div
+          className="pointer-events-none absolute bottom-20 left-0 right-0 z-20 flex justify-center px-4 sm:bottom-24"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 16 }}
+          transition={{ duration: 0.4, ease: 'easeOut', delay: 0.3 }}
+        >
+          {/* Card: pointer-events:auto restores interactivity on the card itself */}
+          <div className="pointer-events-auto relative w-full max-w-xs rounded-xl border border-border bg-card p-4 shadow-lg sm:max-w-sm">
+            {/* Dismiss */}
+            <button
+              onClick={() => setDismissed(true)}
+              className="absolute right-3 top-3 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Dismiss prompt"
+            >
+              <X size={14} />
+            </button>
+
+            {/* Icon + headline */}
+            <div className="mb-1 flex items-center gap-2">
+              <MapPin size={16} className="shrink-0 text-primary" />
+              <p className="font-kalam text-base font-bold leading-tight text-foreground">
+                Leave your mark.
+              </p>
+            </div>
+
+            {/* Body */}
+            <p className="mb-3 font-hand text-sm text-muted-foreground">
+              No one has pinned your story here yet. Add your first memory to
+              the map.
+            </p>
+
+            {/* CTA */}
+            <button
+              onClick={onAddMemory}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 font-hand text-sm font-medium text-primary-foreground shadow transition-all hover:bg-primary/90 active:scale-95"
+            >
+              Pin a Memory
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
- Created an overlay for the campus map that prompts authenticated users with no posts to create their first memory.
- Configured conditional logic to show the prompt only after authentication is confirmed and memory checks return empty.
- Implemented a session-based dismiss function that allows the prompt to reappear upon future visits.
- Adjusted pointer event settings to ensure the underlying map and existing controls remain fully interactive.
- Connected the call to action button to the existing memory creation modal for a consistent user flow.