### PR TITLE
Invite link permission

### DIFF
--- a/prisma/migrations/20260421050308_add_invitation_public_link_fields/migration.sql
+++ b/prisma/migrations/20260421050308_add_invitation_public_link_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Invitation" ADD COLUMN     "isForAll" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "maxUses" INTEGER NOT NULL DEFAULT 1,
+ALTER COLUMN "email" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -273,8 +273,10 @@ model Invitation {
   id        String       @id @default(uuid()) @db.Uuid
   groupId   String       @db.Uuid
   invitedBy String       @db.Uuid
-  email     String       @db.VarChar(255)
+  email     String?      @db.VarChar(255)
   token     String       @unique @db.VarChar(64)
+  isForAll  Boolean      @default(false)
+  maxUses   Int          @default(1)
   expiresAt DateTime
   createdAt DateTime     @default(now())
   group     PrivateGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)

--- a/src/app/api/prisma/invitation/accept/route.ts
+++ b/src/app/api/prisma/invitation/accept/route.ts
@@ -83,23 +83,36 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // ── 6b. Verify token belongs to the authenticated user ──────────
-    if (
-      invitation.email &&
-      dbUser.email.toLowerCase() !== invitation.email.toLowerCase()
-    ) {
-      return NextResponse.json(
-        { error: 'Invalid invitation link' },
-        { status: 403 }
-      );
+    // ── 6b. Validate based on invitation type ──────────────────────
+    if (invitation.isForAll) {
+      // Public link: check if uses remain
+      if (invitation.maxUses <= 0) {
+        return NextResponse.json(
+          { error: 'This invitation link has been fully used' },
+          { status: 410 }
+        );
+      }
+    } else {
+      // Targeted link: verify token belongs to the authenticated user
+      if (
+        invitation.email &&
+        dbUser.email.toLowerCase() !== invitation.email.toLowerCase()
+      ) {
+        return NextResponse.json(
+          { error: 'Invalid invitation link' },
+          { status: 403 }
+        );
+      }
     }
 
     // ── 7. Check if already a member ─────────────────────────────────
     const isMember = invitation.group.members.some((m) => m.id === authUser.id);
 
     if (isMember) {
-      // Already a member — just delete the invitation and return
-      await prisma.invitation.delete({ where: { id: invitation.id } });
+      // Already a member — clean up targeted invites, leave public ones
+      if (!invitation.isForAll) {
+        await prisma.invitation.delete({ where: { id: invitation.id } });
+      }
       return NextResponse.json({
         success: true,
         message: 'You are already a member of this group',
@@ -107,31 +120,70 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // ── 8. Add member and delete invitation atomically ───────────────
-    await prisma.$transaction([
-      prisma.privateGroup.update({
-        where: { id: invitation.group.id },
-        data: {
-          members: { connect: { id: dbUser.id } },
-          groupMemberships: {
-            upsert: {
-              where: {
-                groupId_userId: {
-                  groupId: invitation.group.id,
-                  userId: dbUser.id,
+    // ── 8. Add member and handle invitation atomically ───────────────
+    if (invitation.isForAll) {
+      // Public link: decrement maxUses; delete if exhausted
+      const newMaxUses = invitation.maxUses - 1;
+
+      await prisma.$transaction(async (tx) => {
+        await tx.privateGroup.update({
+          where: { id: invitation.group.id },
+          data: {
+            members: { connect: { id: dbUser.id } },
+            groupMemberships: {
+              upsert: {
+                where: {
+                  groupId_userId: {
+                    groupId: invitation.group.id,
+                    userId: dbUser.id,
+                  },
                 },
+                create: {
+                  userId: dbUser.id,
+                  role: 'MEMBER',
+                },
+                update: {},
               },
-              create: {
-                userId: dbUser.id,
-                role: 'MEMBER',
-              },
-              update: {},
             },
           },
-        },
-      }),
-      prisma.invitation.delete({ where: { id: invitation.id } }),
-    ]);
+        });
+
+        if (newMaxUses <= 0) {
+          await tx.invitation.delete({ where: { id: invitation.id } });
+        } else {
+          await tx.invitation.update({
+            where: { id: invitation.id },
+            data: { maxUses: newMaxUses },
+          });
+        }
+      });
+    } else {
+      // Targeted link: add member and delete invitation
+      await prisma.$transaction([
+        prisma.privateGroup.update({
+          where: { id: invitation.group.id },
+          data: {
+            members: { connect: { id: dbUser.id } },
+            groupMemberships: {
+              upsert: {
+                where: {
+                  groupId_userId: {
+                    groupId: invitation.group.id,
+                    userId: dbUser.id,
+                  },
+                },
+                create: {
+                  userId: dbUser.id,
+                  role: 'MEMBER',
+                },
+                update: {},
+              },
+            },
+          },
+        }),
+        prisma.invitation.delete({ where: { id: invitation.id } }),
+      ]);
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/prisma/invitation/link/route.ts
+++ b/src/app/api/prisma/invitation/link/route.ts
@@ -1,8 +1,8 @@
 import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { prisma } from '@/lib/prisma';
+import { createInvitationLinkSchema } from '@/lib/schemas';
 import {
   canRoleUsePermission,
   resolveGroupMemberRole,
@@ -10,17 +10,14 @@ import {
 
 const INVITATION_EXPIRY_DAYS = 7;
 
-const createInvitationLinkSchema = z.object({
-  groupId: z.string().uuid('Invalid group ID'),
-});
-
 /**
- * TEMPORARY PATCH:
- * This endpoint exists so invitation links can work right now for role-privilege
- * verification while the invitation system is still being finalized.
+ * POST /api/prisma/invitation/link
  *
- * It keeps the existing invitation system untouched and only adds a link-only
- * token generation path.
+ * Generates a public, multi-use invitation link for a group.
+ * The link is not tied to a specific email and can be used by
+ * anyone up to `maxUses` times.
+ *
+ * Requires sendInvitations privilege for the actor role.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -45,7 +42,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { groupId } = parsed.data;
+    const { groupId, maxUses } = parsed.data;
 
     // ── 3. Authorise actor by current role privileges ────────────────
     const group = await prisma.privateGroup.findUnique({
@@ -91,7 +88,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // ── 4. Create invitation token ───────────────────────────────────
+    // ── 4. Create public invitation token ─────────────────────────────
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + INVITATION_EXPIRY_DAYS);
 
@@ -99,16 +96,16 @@ export async function POST(request: NextRequest) {
       data: {
         groupId,
         invitedBy: authUser.id,
-        // Keep the current schema intact: invitation requires an email.
-        // For link-only generation, we store the actor email as audit metadata.
-        email:
-          authUser.email?.toLowerCase() ?? 'temporary-link@skolaroid.local',
+        email: null,
         token: crypto.randomBytes(32).toString('hex'),
+        isForAll: true,
+        maxUses,
         expiresAt,
       },
       select: {
         id: true,
         token: true,
+        maxUses: true,
         expiresAt: true,
       },
     });
@@ -120,12 +117,14 @@ export async function POST(request: NextRequest) {
       data: {
         id: invitation.id,
         inviteLink: `${origin}/invite?token=${invitation.token}`,
+        maxUses: invitation.maxUses,
         expiresAt: invitation.expiresAt.toISOString(),
       },
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message =
+      error instanceof Error ? error.stack || error.message : 'Unknown error';
     console.error('[invitation/link] Error:', message);
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json({ error: String(message) }, { status: 500 });
   }
 }

--- a/src/app/api/prisma/invitation/send/route.ts
+++ b/src/app/api/prisma/invitation/send/route.ts
@@ -101,6 +101,8 @@ export async function POST(request: NextRequest) {
             invitedBy: authUser.id,
             email: email.toLowerCase(),
             token,
+            isForAll: false,
+            maxUses: 1,
             expiresAt,
           },
           select: { id: true, email: true, token: true, expiresAt: true },
@@ -112,7 +114,7 @@ export async function POST(request: NextRequest) {
     const origin = request.headers.get('origin') ?? request.nextUrl.origin;
     const results = invitations.map((inv) => ({
       id: inv.id,
-      email: inv.email,
+      email: inv.email!,
       inviteLink: `${origin}/invite?token=${inv.token}`,
       expiresAt: inv.expiresAt.toISOString(),
     }));

--- a/src/app/api/prisma/invitation/validate/route.ts
+++ b/src/app/api/prisma/invitation/validate/route.ts
@@ -88,19 +88,34 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // ── 5. Verify token belongs to the authenticated user ────────────
-    if (
-      invitation.email &&
-      authUser.email?.toLowerCase() !== invitation.email.toLowerCase()
-    ) {
-      return NextResponse.json(
-        {
-          error: 'Invalid invitation link',
-          code: 'WRONG_USER',
-          groupName: invitation.group.name,
-        },
-        { status: 403 }
-      );
+    // ── 5. Validate based on invitation type ────────────────────────
+    if (invitation.isForAll) {
+      // Public link: check if uses remain
+      if (invitation.maxUses <= 0) {
+        return NextResponse.json(
+          {
+            error: 'This invitation link has been fully used',
+            code: 'EXHAUSTED',
+            groupName: invitation.group.name,
+          },
+          { status: 410 }
+        );
+      }
+    } else {
+      // Targeted link: verify token belongs to the authenticated user
+      if (
+        invitation.email &&
+        authUser.email?.toLowerCase() !== invitation.email.toLowerCase()
+      ) {
+        return NextResponse.json(
+          {
+            error: 'Invalid invitation link',
+            code: 'WRONG_USER',
+            groupName: invitation.group.name,
+          },
+          { status: 403 }
+        );
+      }
     }
 
     // ── 6. Check if already a member ─────────────────────────────────
@@ -112,6 +127,7 @@ export async function GET(request: NextRequest) {
         invitation: {
           id: invitation.id,
           email: invitation.email,
+          isForAll: invitation.isForAll,
           expiresAt: invitation.expiresAt.toISOString(),
           token: invitation.token,
         },

--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -126,7 +126,7 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const [editMessageModalOpen, setEditMessageModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType>('members');
 
-  const { showSuccess, showError } = useGroupToast();
+  const { showSuccess, showError, ToastPortal } = useGroupToast();
   const { user } = useUserAuth();
   const currentUserId = user?.id ?? '';
 
@@ -620,6 +620,8 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
           )}
         </>
       )}
+
+      <ToastPortal />
     </>
   );
 }

--- a/src/components/groups/GroupToast.tsx
+++ b/src/components/groups/GroupToast.tsx
@@ -38,9 +38,9 @@ function ToastCard({
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 20 }}
+      exit={{ opacity: 0, y: -20 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
       className={`flex min-w-[280px] max-w-sm items-center gap-3 rounded-xl border bg-white px-4 py-3 shadow-xl ${borderClass}`}
       role="alert"
@@ -97,7 +97,7 @@ export function useGroupToast(): GroupToastHook {
     if (!mounted) return null;
 
     return createPortal(
-      <div className="pointer-events-none fixed bottom-6 left-1/2 z-[200] -translate-x-1/2">
+      <div className="pointer-events-none fixed left-1/2 top-4 z-[300] -translate-x-1/2">
         <AnimatePresence mode="wait">
           {toast && (
             <div className="pointer-events-auto">

--- a/src/components/groups/InviteMembersModal.tsx
+++ b/src/components/groups/InviteMembersModal.tsx
@@ -4,11 +4,8 @@ import { useState } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Link2, Mail, Copy, Check, Loader2 } from 'lucide-react';
-import {
-  useCreateInvitationLink,
-  useSendInvitations,
-} from '@/lib/hooks/useInvitation';
+import { Mail, Loader2 } from 'lucide-react';
+import { useSendInvitations } from '@/lib/hooks/useInvitation';
 
 interface InviteMembersModalProps {
   open: boolean;
@@ -26,50 +23,9 @@ export function InviteMembersModal({
   showSuccess,
 }: InviteMembersModalProps) {
   const [emails, setEmails] = useState('');
-  const [linkCopied, setLinkCopied] = useState(false);
-  const [temporaryInviteLink, setTemporaryInviteLink] = useState('');
   const sendInvitations = useSendInvitations();
-  const createInvitationLink = useCreateInvitationLink();
-
-  // TODO: Replace with real invite link generation via API
-  // NOTE: Kept as-is to preserve the current invitation system behavior.
-  //const inviteLink = `${typeof window !== 'undefined' ? window.location.origin : ''}/invite/${groupId}`;
-
-  const handleCopyLink = async () => {
-    try {
-      // Legacy behavior (kept intentionally, not removed):
-      // await navigator.clipboard.writeText(inviteLink);
-
-      // TEMPORARY PATCH:
-      // Use tokenized invite link generation to make invites work immediately
-      // for role-privilege verification.
-      const generatedLink =
-        temporaryInviteLink ||
-        (await createInvitationLink.mutateAsync(groupId)).inviteLink;
-
-      if (!temporaryInviteLink) {
-        setTemporaryInviteLink(generatedLink);
-      }
-
-      await navigator.clipboard.writeText(generatedLink);
-      setLinkCopied(true);
-      showSuccess('Invite link copied!');
-      setTimeout(() => setLinkCopied(false), 2000);
-    } catch {
-      // Fallback: select the text for manual copy
-    }
-  };
 
   const handleSendInvites = async () => {
-    console.log('Sending invites to:', emails);
-    console.log(
-      'Parsed emails:',
-      emails
-        .split(',')
-        .map((e) => e.trim())
-        .filter((e) => e.length > 0)
-    );
-    console.log('Group ID:', groupId);
     if (!emails.trim()) return;
 
     const emailList = emails
@@ -94,10 +50,7 @@ export function InviteMembersModal({
 
   const handleClose = () => {
     setEmails('');
-    setLinkCopied(false);
-    setTemporaryInviteLink('');
     sendInvitations.reset();
-    createInvitationLink.reset();
     onOpenChange(false);
   };
 
@@ -118,44 +71,14 @@ export function InviteMembersModal({
               Invite Members
             </h2>
             <p className="mt-1 text-xs text-muted-foreground">
-              Share a link or invite people by email.
+              Send invitations by email.
             </p>
           </div>
 
-          {/* Invite Link */}
-          <div className="min-w-0 space-y-2 px-6 pt-4">
-            <label className="text-xs font-medium text-muted-foreground">
-              Invite Link
-            </label>
-            <div className="flex min-w-0 items-center gap-2">
-              <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden border-2 border-border bg-secondary px-3 py-2.5">
-                <Link2 size={14} className="shrink-0 text-muted-foreground" />
-                <span className="truncate text-xs text-foreground">
-                  {temporaryInviteLink}
-                </span>
-              </div>
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={handleCopyLink}
-                disabled={createInvitationLink.isPending}
-                aria-label="Copy invite link"
-              >
-                {createInvitationLink.isPending ? (
-                  <Loader2 size={15} className="animate-spin" />
-                ) : linkCopied ? (
-                  <Check size={15} className="text-green-500" />
-                ) : (
-                  <Copy size={15} />
-                )}
-              </Button>
-            </div>
-          </div>
-
-          {/* Email Invites */}
+          {/* Email Input */}
           <div className="space-y-2 px-6 pt-4">
             <label className="text-xs font-medium text-muted-foreground">
-              Invite by Email
+              Email Address
             </label>
             <div className="relative">
               <Mail
@@ -178,12 +101,6 @@ export function InviteMembersModal({
                 {sendInvitations.error?.message ?? 'Failed to send invitations'}
               </p>
             )}
-            {createInvitationLink.isError && (
-              <p className="text-xs text-red-500">
-                {createInvitationLink.error?.message ??
-                  'Failed to generate invitation link'}
-              </p>
-            )}
             <div className="flex justify-end gap-2">
               <Button variant="ghost" onClick={handleClose}>
                 Cancel
@@ -195,7 +112,7 @@ export function InviteMembersModal({
                 {sendInvitations.isPending && (
                   <Loader2 size={14} className="animate-spin" />
                 )}
-                Send Invites
+                Send Invite
               </Button>
             </div>
           </div>

--- a/src/components/groups/ShareGroupModal.tsx
+++ b/src/components/groups/ShareGroupModal.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Copy, Check } from 'lucide-react';
+import { Link2, Copy, Check, Loader2, RefreshCw } from 'lucide-react';
+import { useCreateInvitationLink } from '@/lib/hooks/useInvitation';
 
 interface ShareGroupModalProps {
   open: boolean;
@@ -20,70 +22,141 @@ export function ShareGroupModal({
   groupId,
   showSuccess,
 }: ShareGroupModalProps) {
-  const [copied, setCopied] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+  const [generatedLink, setGeneratedLink] = useState('');
+  const [maxUses, setMaxUses] = useState(10);
+  const createInvitationLink = useCreateInvitationLink();
 
-  // TODO: Replace with real shareable link via API
-  const shareLink = `${typeof window !== 'undefined' ? window.location.origin : ''}/groups/${groupId}`;
-
-  const handleCopy = async () => {
+  const handleGenerateLink = async () => {
     try {
-      await navigator.clipboard.writeText(shareLink);
-      setCopied(true);
+      const result = await createInvitationLink.mutateAsync({
+        groupId,
+        maxUses,
+      });
+      setGeneratedLink(result.inviteLink);
+      showSuccess('Invite link generated!');
+    } catch {
+      // Error is shown through the mutation state
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!generatedLink) return;
+    try {
+      await navigator.clipboard.writeText(generatedLink);
+      setLinkCopied(true);
       showSuccess('Link copied to clipboard!');
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setLinkCopied(false), 2000);
     } catch {
       // Fallback
     }
   };
 
   const handleClose = () => {
-    setCopied(false);
+    setLinkCopied(false);
+    setGeneratedLink('');
+    setMaxUses(10);
+    createInvitationLink.reset();
     onOpenChange(false);
   };
 
   return (
     <Dialog open={open} onOpenChange={(val) => !val && handleClose()}>
       <DialogContent
-        className="max-w-xs gap-0 overflow-hidden p-0"
+        className="max-h-[90vh] w-[calc(100%-2rem)] max-w-sm gap-0 overflow-hidden p-0"
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">Share {groupName}</DialogTitle>
 
-        <div className="flex flex-col">
+        <div className="flex min-w-0 flex-col">
+          {/* Header */}
           <div className="px-6 pb-1 pt-6">
             <h2 className="font-kalam text-base font-semibold text-foreground">
               Share Group
             </h2>
             <p className="mt-1 text-xs text-muted-foreground">
-              Copy the link to share this group.
+              Generate a public invite link for this group.
             </p>
           </div>
 
-          <div className="px-6 pt-4">
-            <div className="flex items-center gap-2 border-2 border-border bg-secondary px-3 py-2.5">
-              <span className="min-w-0 flex-1 truncate text-xs text-foreground">
-                {shareLink}
-              </span>
+          {/* Max uses + Generate */}
+          <div className="min-w-0 space-y-2 px-6 pt-4">
+            <label className="text-xs font-medium text-muted-foreground">
+              Invite Link
+            </label>
+
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="flex items-center gap-1.5">
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  Max uses:
+                </span>
+                <Input
+                  type="number"
+                  min={1}
+                  max={1000}
+                  className="h-8 w-20 border-border bg-secondary text-center text-xs"
+                  value={maxUses}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value, 10);
+                    if (!isNaN(val) && val >= 1 && val <= 1000) {
+                      setMaxUses(val);
+                    }
+                  }}
+                />
+              </div>
               <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleCopy}
-                className="h-7 w-7 shrink-0"
-                aria-label="Copy link"
+                variant="outline"
+                size="sm"
+                onClick={handleGenerateLink}
+                disabled={createInvitationLink.isPending}
+                className="shrink-0"
               >
-                {copied ? (
-                  <Check size={14} className="text-green-500" />
+                {createInvitationLink.isPending ? (
+                  <Loader2 size={14} className="animate-spin" />
                 ) : (
-                  <Copy size={14} />
+                  <RefreshCw size={14} />
+                )}
+                Generate
+              </Button>
+            </div>
+
+            {/* Generated link display + copy */}
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden border-2 border-border bg-secondary px-3 py-2.5">
+                <Link2 size={14} className="shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate text-xs text-foreground">
+                  {generatedLink || 'Click Generate to create a link'}
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handleCopyLink}
+                disabled={!generatedLink}
+                aria-label="Copy invite link"
+              >
+                {linkCopied ? (
+                  <Check size={15} className="text-green-500" />
+                ) : (
+                  <Copy size={15} />
                 )}
               </Button>
             </div>
           </div>
 
-          <div className="flex justify-end px-6 pb-6 pt-5">
-            <Button variant="ghost" onClick={handleClose}>
-              Done
-            </Button>
+          {/* Footer */}
+          <div className="flex flex-col gap-2 px-6 pb-6 pt-5">
+            {createInvitationLink.isError && (
+              <p className="text-xs text-red-500">
+                {createInvitationLink.error?.message ??
+                  'Failed to generate invitation link'}
+              </p>
+            )}
+            <div className="flex justify-end">
+              <Button variant="ghost" onClick={handleClose}>
+                Done
+              </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -29,6 +29,7 @@ export function LoginForm({
         redirectTo: `${origin}/auth/callback`,
         queryParams: {
           hd: 'up.edu.ph',
+          prompt: 'select_account',
         },
       },
     });

--- a/src/lib/hooks/useInvitation.ts
+++ b/src/lib/hooks/useInvitation.ts
@@ -14,6 +14,7 @@ interface SendInvitationsResult {
 interface CreateInvitationLinkResult {
   id: string;
   inviteLink: string;
+  maxUses: number;
   expiresAt: string;
 }
 
@@ -21,6 +22,7 @@ export interface ValidateInvitationData {
   invitation: {
     id: string;
     email: string;
+    isForAll: boolean;
     expiresAt: string;
     token: string;
   };
@@ -79,19 +81,18 @@ export function useSendInvitations() {
 }
 
 /**
- * TEMPORARY PATCH:
- * Generates a tokenized invitation link for quick verification flows.
- * Existing invitation-by-email hooks remain unchanged.
+ * Generates a public, multi-use invitation link for a group.
  */
 export function useCreateInvitationLink() {
   return useMutation({
-    mutationFn: async (
-      groupId: string
-    ): Promise<CreateInvitationLinkResult> => {
+    mutationFn: async (data: {
+      groupId: string;
+      maxUses: number;
+    }): Promise<CreateInvitationLinkResult> => {
       const res = await fetch('/api/prisma/invitation/link', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ groupId }),
+        body: JSON.stringify(data),
       });
 
       const body = await res.json();

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -471,8 +471,21 @@ export const invitationActionSchema = z.object({
   token: z.string().min(1, 'Token is required'),
 });
 
+/** Schema for generating a public invitation link. */
+export const createInvitationLinkSchema = z.object({
+  groupId: z.string().uuid('Invalid group ID'),
+  maxUses: z
+    .number({ error: 'Max uses must be a number' })
+    .int('Max uses must be a whole number')
+    .min(1, 'Max uses must be at least 1')
+    .max(1000, 'Max uses cannot exceed 1000'),
+});
+
 export type SendInvitationsInput = z.infer<typeof sendInvitationsSchema>;
 export type InvitationTokenInput = z.infer<typeof invitationTokenSchema>;
+export type CreateInvitationLinkInput = z.infer<
+  typeof createInvitationLinkSchema
+>;
 export type InvitationActionInput = z.infer<typeof invitationActionSchema>;
 
 // ============================================================================


### PR DESCRIPTION
- Separated inviting individual members
- Share group can now generate invite link that has n max uses
- A toast ui is shown after successful invitation
- Prisma schema changes: Added max_uses and is_for_all columns for the public link invitation