### PR TITLE
feat(map): implement case-insensitive search predicate in memory filt…

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -162,6 +162,10 @@ export default function MapPage() {
     []
   );
 
+  const handleSearchChange = useCallback((query: string) => {
+    setFilters((prev) => ({ ...prev, searchQuery: query }));
+  }, []);
+
   return (
     <div className="relative h-dvh overflow-hidden bg-background">
       <Header hidden={headerTucked} variant="floating" />
@@ -212,6 +216,7 @@ export default function MapPage() {
                 availableYears={availableYears}
                 availableGroups={availableGroups}
                 availableLocations={availableLocations}
+                onSearchChange={handleSearchChange}
               />
             ) : null}
           </div>

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -204,7 +204,24 @@ export function MapComponent({
 
   const tagFilteredMemories = useMemo(() => {
     return eraFilteredMemories.filter((memory) => {
-      // Tag filter
+      // ── SEARCH FILTER (live, applied first) ────────────────────────────────
+      if (filters.searchQuery && filters.searchQuery.trim()) {
+        const q = filters.searchQuery.toLowerCase().trim();
+        const inTitle = (memory.title ?? '').toLowerCase().includes(q);
+        const inDesc = (memory.description ?? '').toLowerCase().includes(q);
+        const inLocation = (
+          (memory.location as { buildingName?: string } | undefined)
+            ?.buildingName ?? ''
+        )
+          .toLowerCase()
+          .includes(q);
+        const inTags = (memory.tags ?? []).some((t) =>
+          t.name.toLowerCase().includes(q)
+        );
+        if (!inTitle && !inDesc && !inLocation && !inTags) return false;
+      }
+
+      // ── TAG FILTER (unchanged) ─────────────────────────────────────────────
       if (filters.selectedTags.length > 0) {
         const memoryTagNames = memory.tags?.map((t) => t.name) ?? [];
         const hasAllTags = filters.selectedTags.every((tag) =>
@@ -213,7 +230,7 @@ export function MapComponent({
         if (!hasAllTags) return false;
       }
 
-      // Year filter
+      // ── YEAR FILTER (unchanged) ────────────────────────────────────────────
       if (filters.selectedYear) {
         const memoryDateValue = (memory as { memoryDate?: string }).memoryDate;
         const memoryYear = memoryDateValue
@@ -222,17 +239,17 @@ export function MapComponent({
         if (memoryYear !== filters.selectedYear) return false;
       }
 
-      // Visibility filter
+      // ── VISIBILITY FILTER (unchanged) ─────────────────────────────────────
       if (filters.visibility !== 'ALL') {
         if (memory.visibility !== filters.visibility) return false;
       }
 
-      // Group filter
+      // ── GROUP FILTER (unchanged) ───────────────────────────────────────────
       if (filters.selectedGroupId) {
         if (memory.privateGroupId !== filters.selectedGroupId) return false;
       }
 
-      // Location filter
+      // ── LOCATION FILTER (unchanged) ───────────────────────────────────────
       if (filters.selectedLocationId) {
         const locationId = (memory.location as { id?: string } | undefined)?.id;
         if (locationId !== filters.selectedLocationId) return false;

--- a/src/components/map/FilterMemoriesModal.tsx
+++ b/src/components/map/FilterMemoriesModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { X, ChevronDown } from 'lucide-react';
+import { X, ChevronDown, Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -40,6 +40,7 @@ export interface MemoryFilters {
   selectedYear: number | null;
   selectedGroupId: string | null;
   selectedLocationId: string | null;
+  searchQuery: string;
 }
 
 export const DEFAULT_FILTERS: MemoryFilters = {
@@ -49,6 +50,7 @@ export const DEFAULT_FILTERS: MemoryFilters = {
   selectedYear: null,
   selectedGroupId: null,
   selectedLocationId: null,
+  searchQuery: '',
 };
 
 export interface GroupFilterOption {
@@ -83,6 +85,7 @@ interface FilterMemoriesPanelProps {
   availableGroups?: GroupFilterOption[];
   availableLocations?: LocationFilterOption[];
   className?: string;
+  onSearchChange?: (query: string) => void;
 }
 
 // =============================================================================
@@ -136,6 +139,7 @@ export function FilterMemoriesPanel({
   availableGroups = [],
   availableLocations = [],
   className,
+  onSearchChange,
 }: FilterMemoriesPanelProps) {
   const [draft, setDraft] = useState<MemoryFilters>(filters);
 
@@ -147,7 +151,8 @@ export function FilterMemoriesPanel({
 
   const handleClearAll = useCallback(() => {
     setDraft(DEFAULT_FILTERS);
-  }, []);
+    onSearchChange?.('');
+  }, [onSearchChange]);
 
   const handleApply = useCallback(() => {
     onApply(draft);
@@ -186,6 +191,40 @@ export function FilterMemoriesPanel({
             <X className="h-4 w-4" />
           </button>
         ) : null}
+      </div>
+
+      {/* Search bar — live filter, no Apply needed */}
+      <div className="border-b px-5 py-3">
+        <div
+          className="flex items-center gap-2 border-2 border-border bg-card px-3 py-2 shadow-[4px_4px_0px_0px_#2d2d2d] transition-all"
+          style={{ borderRadius: WOBBLY_RADIUS }}
+        >
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            type="text"
+            value={draft.searchQuery}
+            onChange={(e) => {
+              const q = e.target.value;
+              setDraft((prev) => ({ ...prev, searchQuery: q }));
+              onSearchChange?.(q);
+            }}
+            placeholder="Search memories..."
+            className="flex-1 bg-transparent font-hand text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+          />
+          {draft.searchQuery ? (
+            <button
+              type="button"
+              onClick={() => {
+                setDraft((prev) => ({ ...prev, searchQuery: '' }));
+                onSearchChange?.('');
+              }}
+              className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+        </div>
       </div>
 
       <div className="scrollbar-hide flex-1 overflow-y-auto px-6 py-4">


### PR DESCRIPTION
- Added searchQuery to the MemoryFilters interface and initialized it in DEFAULT_FILTERS to support text-based lookups.
- Integrated a search input with hand-drawn styling, WOBBLY_RADIUS, and an inline clear button into the filter panel UI.
- Updated the tagFilteredMemories memoized predicate to perform case-insensitive substring matches against titles, descriptions, tags, and building names.
- Wired the handleSearchChange callback in the map page to ensure search narrows the data pool before applying other AND-composed filters.
- Confirmed that modified files are type-safe; pre-existing TypeScript errors are isolated to unrelated invitation and upload routes.