### PR TITLE
feat: show pending clock badges on pins

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -212,11 +212,6 @@ function PostCard({
       {/* Content */}
       <div className="flex min-w-0 flex-1 flex-col gap-2">
         <p className="text-sm font-medium text-foreground">{memory.title}</p>
-        {memory.description && (
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            {memory.description}
-          </p>
-        )}
 
         <div className="flex items-center gap-4">
           {/* Date */}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1022,6 +1022,7 @@ export function MapComponent({
           <MemoryPin
             src={memory.mediaURL!}
             alt={memory.title}
+            isPending={memory.moderationStatus === 'PENDING'}
             onClick={() => handleMemoryClick(memory)}
           />
         );
@@ -1034,6 +1035,7 @@ export function MapComponent({
                 id: m.id,
                 title: m.title,
                 mediaURL: m.mediaURL!,
+                isPending: m.moderationStatus === 'PENDING',
               }))}
             onClick={(memoryId) => {
               const found = group.memories.find((m) => m.id === memoryId);

--- a/src/components/map/MemoryPin.tsx
+++ b/src/components/map/MemoryPin.tsx
@@ -1,21 +1,35 @@
 'use client';
 
 import Image from 'next/image';
+import { Clock } from 'lucide-react';
 
 export interface MemoryPinProps {
   src: string;
   alt?: string;
+  isPending?: boolean;
   onClick?: () => void;
 }
 
-export function MemoryPin({ src, alt = 'Memory', onClick }: MemoryPinProps) {
+export function MemoryPin({
+  src,
+  alt = 'Memory',
+  isPending = false,
+  onClick,
+}: MemoryPinProps) {
+  const ariaLabel = isPending ? `${alt} (Pending approval)` : alt;
+
   return (
     <button
       type="button"
       onClick={onClick}
       className="group relative w-fit cursor-pointer transition-transform duration-200 hover:-translate-y-1"
-      aria-label={alt}
+      aria-label={ariaLabel}
     >
+      {isPending && (
+        <span className="absolute -right-2 -top-2 z-20 flex h-5 w-5 items-center justify-center rounded-full border-2 border-black bg-amber-200 text-black shadow-sm">
+          <Clock className="h-3 w-3" aria-hidden="true" />
+        </span>
+      )}
       <div className="relative w-[74px] rounded-md border-2 border-black bg-white px-[5px] pb-[20px] pt-[5px]">
         <div className="relative aspect-square w-full overflow-hidden rounded-sm border-[1px] border-black bg-neutral-100">
           <Image src={src} alt={alt} fill className="object-cover" />

--- a/src/components/map/MemoryPinStack.tsx
+++ b/src/components/map/MemoryPinStack.tsx
@@ -2,11 +2,13 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import Image from 'next/image';
+import { Clock } from 'lucide-react';
 
 interface StackedMemory {
   id: string;
   title: string;
   mediaURL: string;
+  isPending?: boolean;
 }
 
 interface MemoryPinStackProps {
@@ -22,6 +24,8 @@ const MAX_VISIBLE_PINS = 8;
  */
 export function MemoryPinStack({ memories, onClick }: MemoryPinStackProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const pendingBadgeClassName =
+    'absolute -right-2 -top-2 z-20 flex h-5 w-5 items-center justify-center rounded-full border-2 border-black bg-amber-200 text-black shadow-sm';
 
   const visibleMemories = useMemo(
     () => memories.slice(0, MAX_VISIBLE_PINS),
@@ -69,13 +73,21 @@ export function MemoryPinStack({ memories, onClick }: MemoryPinStackProps) {
   // Single memory — just render a normal pin
   if (memories.length === 1) {
     const mem = memories[0];
+    const ariaLabel = mem.isPending
+      ? `${mem.title} (Pending approval)`
+      : mem.title;
     return (
       <button
         type="button"
         onClick={() => onClick(mem.id)}
         className="group relative w-fit cursor-pointer transition-transform duration-200 hover:-translate-y-1"
-        aria-label={mem.title}
+        aria-label={ariaLabel}
       >
+        {mem.isPending && (
+          <span className={pendingBadgeClassName}>
+            <Clock className="h-3 w-3" aria-hidden="true" />
+          </span>
+        )}
         <div className="relative w-[74px] rounded-md border-2 border-black bg-white px-[5px] pb-[20px] pt-[5px]">
           <div className="relative aspect-square w-full overflow-hidden rounded-sm border-[1px] border-black bg-neutral-100">
             <Image
@@ -108,8 +120,15 @@ export function MemoryPinStack({ memories, onClick }: MemoryPinStackProps) {
           }}
           className="absolute left-0 top-0 w-[74px] cursor-pointer transition-transform duration-200 hover:-translate-y-1"
           style={getFanOutStyle(index)}
-          aria-label={mem.title}
+          aria-label={
+            mem.isPending ? `${mem.title} (Pending approval)` : mem.title
+          }
         >
+          {mem.isPending && (
+            <span className={pendingBadgeClassName}>
+              <Clock className="h-3 w-3" aria-hidden="true" />
+            </span>
+          )}
           <div className="relative w-[74px] rounded-md border-2 border-black bg-white px-[5px] pb-[20px] pt-[5px]">
             <div className="relative aspect-square w-full overflow-hidden rounded-sm border-[1px] border-black bg-neutral-100">
               <Image

--- a/src/lib/hooks/useModerateMemory.ts
+++ b/src/lib/hooks/useModerateMemory.ts
@@ -31,6 +31,9 @@ export function useModerateMemory() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin-memories'] });
       queryClient.invalidateQueries({ queryKey: ['admin-analytics'] });
+      queryClient.invalidateQueries({ queryKey: ['memories'] });
+      queryClient.invalidateQueries({ queryKey: ['memory-counts'] });
+      queryClient.invalidateQueries({ queryKey: ['public-gallery'] });
     },
   });
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -327,6 +327,7 @@ export interface MemoryWithRelations {
   mediaURL?: string | null;
   mediaURLs?: string[];
   visibility: MemoryVisibility;
+  moderationStatus?: ModerationStatus;
   creatorId?: string | null;
   privateGroupId?: string | null;
   createdAt?: string;


### PR DESCRIPTION
Include moderation status in memory types and pass it to map pins.

Render clock badge for pending single and stacked pins without breaking layout.

Invalidate memory-related queries after moderation so map state refreshes.

Remove duplicate caption description from admin post cards.