### PR TITLE
SCRUM-140-add-caption-indicator

### DIFF
--- a/src/components/gallery/GalleryMemoryCard.tsx
+++ b/src/components/gallery/GalleryMemoryCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Image from 'next/image';
 import { User } from 'lucide-react';
 import { PolaroidCluster } from './PolaroidCluster';
@@ -31,6 +32,8 @@ export function GalleryMemoryCard({
   index = 0,
   onClick,
 }: GalleryMemoryCardProps) {
+  const [isHovered, setIsHovered] = useState(false);
+
   const photos = memory.mediaURL
     ? [{ src: memory.mediaURL, alt: memory.title }]
     : [];
@@ -48,11 +51,35 @@ export function GalleryMemoryCard({
 
   return (
     <div className="flex shrink-0 flex-col items-center">
-      <PolaroidCluster
-        photos={photos}
-        startIndex={index}
-        onPhotoClick={onClick}
-      />
+      <div className="relative">
+        <PolaroidCluster
+          photos={photos}
+          startIndex={index}
+          onPhotoClick={onClick}
+        />
+
+        {/* Caption Overlay */}
+        <div
+          className={`pointer-events-none absolute inset-[-10rem] z-10 flex items-center justify-center p-8 transition-opacity duration-300 ${
+            isHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={{
+            /* Smooth exponential decay fade out to infinity */
+            background:
+              'radial-gradient(ellipse 40% 50% at center, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.5) 25%, rgba(0,0,0,0.25) 50%, rgba(0,0,0,0.08) 75%, transparent 100%)',
+          }}
+        >
+          <p
+            className="text-center font-dancing italic leading-[1.15] text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]"
+            style={{
+              fontSize: captionFontSize(captionText),
+              maxWidth: '30rem',
+            }}
+          >
+            {captionText}
+          </p>
+        </div>
+      </div>
       <div
         className="flex flex-col items-center text-center"
         style={{
@@ -61,7 +88,13 @@ export function GalleryMemoryCard({
         }}
       >
         {/* Avatar + uploader name */}
-        <div className="flex items-center gap-2">
+        <div
+          className="flex cursor-pointer items-center gap-2 transition-opacity hover:opacity-80"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          onFocus={() => setIsHovered(true)}
+          onBlur={() => setIsHovered(false)}
+        >
           <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border-2 border-border bg-secondary">
             {uploaderPhoto ? (
               <Image
@@ -81,13 +114,6 @@ export function GalleryMemoryCard({
             </span>
           )}
         </div>
-        {/* Caption */}
-        <p
-          className="hidden font-dancing italic leading-[1.15] text-gray-700"
-          style={{ fontSize: captionFontSize(captionText), maxWidth: '14rem' }}
-        >
-          {captionText}
-        </p>
         {/* Date */}
         {dateUploaded && (
           <span className="hidden font-hand text-xs text-gray-400">

--- a/src/components/gallery/GalleryMemoryCard.tsx
+++ b/src/components/gallery/GalleryMemoryCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import { User } from 'lucide-react';
 import { PolaroidCluster } from './PolaroidCluster';
@@ -8,7 +8,7 @@ import { SpeechBubble } from '@/components/speech-bubble';
 import type { MemoryWithCoordinates } from '@/lib/hooks/useAllMemoriesWithCoordinates';
 
 // DEV TOGGLE: Set to true to use the speech bubble overlay instead of the cinematic vignette
-const USE_SPEECH_BUBBLE = false;
+const USE_SPEECH_BUBBLE = true;
 
 function captionFontSize(text: string): string {
   if (text.length <= 10) return '1.55rem';
@@ -37,6 +37,30 @@ export function GalleryMemoryCard({
   onClick,
 }: GalleryMemoryCardProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const nameRef = useRef<HTMLSpanElement>(null);
+  const [nameWidth, setNameWidth] = useState(0);
+
+  const uploaderName = memory.creator
+    ? `${memory.creator.firstName} ${memory.creator.lastName}`.trim()
+    : null;
+
+  // Measure the width of the uploaderName text robustly
+  useEffect(() => {
+    if (!nameRef.current) return;
+
+    // Initial measurement
+    setNameWidth(nameRef.current.getBoundingClientRect().width);
+
+    // Watch for font loading or layout shifts
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setNameWidth(entry.contentRect.width);
+      }
+    });
+
+    observer.observe(nameRef.current);
+    return () => observer.disconnect();
+  }, [uploaderName]);
 
   const photos = memory.mediaURL
     ? [{ src: memory.mediaURL, alt: memory.title }]
@@ -47,11 +71,16 @@ export function GalleryMemoryCard({
   }
 
   const captionText = memory.description || memory.title;
-  const uploaderName = memory.creator
-    ? `${memory.creator.firstName} ${memory.creator.lastName}`.trim()
-    : null;
   const uploaderPhoto = memory.creator?.avatarUrl ?? null;
   const dateUploaded = formatDate(memory.createdAt);
+
+  // Calculate where the tail of the bubble should mathematically point:
+  // The bottom avatar/name container uses gap-2 (8px). Avatar is 36px wide.
+  // The entire row width is: 36 (avatar) + 8 (gap) + nameWidth.
+  // Since the flex row is centered, the left edge of the row is at (-TotalWidth / 2) relative to the flex center.
+  // The avatar is at the left edge. Its center is at (-TotalWidth / 2) + 18.
+  const totalRowWidth = 36 + (uploaderName ? 8 + nameWidth : 0);
+  const avatarCenterOffset = -(totalRowWidth / 2) + 18;
 
   return (
     <div className="flex shrink-0 flex-col items-center">
@@ -62,16 +91,20 @@ export function GalleryMemoryCard({
           onPhotoClick={onClick}
         />
 
-        {/* Caption Overlay */}
-        {USE_SPEECH_BUBBLE ? (
+        {/* Bubble Caption Overlay (Hover) -- Now bound to polaroid center, but tail dynamically points to avatar */}
+        {USE_SPEECH_BUBBLE && (
           <SpeechBubble
             width={280}
             height={110}
             message={captionText}
             visible={isHovered}
-            className="pointer-events-none absolute bottom-[-1rem] left-1/2 z-[100] -translate-x-[20%] translate-y-full"
+            tailPosition={avatarCenterOffset}
+            className="pointer-events-none absolute bottom-[-2rem] left-1/2 z-[100] -translate-x-1/2"
           />
-        ) : (
+        )}
+
+        {/* Cinematic Caption Overlay (Hover) */}
+        {!USE_SPEECH_BUBBLE && (
           <div
             className={`pointer-events-none absolute inset-[-10rem] z-10 flex items-center justify-center p-8 transition-opacity duration-300 ${
               isHovered ? 'opacity-100' : 'opacity-0'
@@ -123,7 +156,10 @@ export function GalleryMemoryCard({
             )}
           </div>
           {uploaderName && (
-            <span className="font-hand text-sm font-semibold text-gray-700">
+            <span
+              ref={nameRef}
+              className="font-hand text-sm font-semibold text-gray-700"
+            >
               {uploaderName}
             </span>
           )}

--- a/src/components/gallery/GalleryMemoryCard.tsx
+++ b/src/components/gallery/GalleryMemoryCard.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { User } from 'lucide-react';
 import { PolaroidCluster } from './PolaroidCluster';
+import { SpeechBubble } from '@/components/speech-bubble';
 import type { MemoryWithCoordinates } from '@/lib/hooks/useAllMemoriesWithCoordinates';
+
+// DEV TOGGLE: Set to true to use the speech bubble overlay instead of the cinematic vignette
+const USE_SPEECH_BUBBLE = false;
 
 function captionFontSize(text: string): string {
   if (text.length <= 10) return '1.55rem';
@@ -59,26 +63,36 @@ export function GalleryMemoryCard({
         />
 
         {/* Caption Overlay */}
-        <div
-          className={`pointer-events-none absolute inset-[-10rem] z-10 flex items-center justify-center p-8 transition-opacity duration-300 ${
-            isHovered ? 'opacity-100' : 'opacity-0'
-          }`}
-          style={{
-            /* Smooth exponential decay fade out to infinity */
-            background:
-              'radial-gradient(ellipse 40% 50% at center, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.5) 25%, rgba(0,0,0,0.25) 50%, rgba(0,0,0,0.08) 75%, transparent 100%)',
-          }}
-        >
-          <p
-            className="text-center font-dancing italic leading-[1.15] text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]"
+        {USE_SPEECH_BUBBLE ? (
+          <SpeechBubble
+            width={280}
+            height={110}
+            message={captionText}
+            visible={isHovered}
+            className="pointer-events-none absolute bottom-[-1rem] left-1/2 z-[100] -translate-x-[20%] translate-y-full"
+          />
+        ) : (
+          <div
+            className={`pointer-events-none absolute inset-[-10rem] z-10 flex items-center justify-center p-8 transition-opacity duration-300 ${
+              isHovered ? 'opacity-100' : 'opacity-0'
+            }`}
             style={{
-              fontSize: captionFontSize(captionText),
-              maxWidth: '30rem',
+              /* Smooth exponential decay fade out to infinity */
+              background:
+                'radial-gradient(ellipse 40% 50% at center, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.5) 25%, rgba(0,0,0,0.25) 50%, rgba(0,0,0,0.08) 75%, transparent 100%)',
             }}
           >
-            {captionText}
-          </p>
-        </div>
+            <p
+              className="text-center font-dancing italic leading-[1.15] text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]"
+              style={{
+                fontSize: captionFontSize(captionText),
+                maxWidth: '30rem',
+              }}
+            >
+              {captionText}
+            </p>
+          </div>
+        )}
       </div>
       <div
         className="flex flex-col items-center text-center"

--- a/src/components/speech-bubble.tsx
+++ b/src/components/speech-bubble.tsx
@@ -26,54 +26,84 @@ interface SpeechBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default true
    */
   visible?: boolean;
+  /**
+   * Position of the tail. Can be 'center', 'right', or a number representing pixel offset from the center
+   * @default 'right'
+   */
+  tailPosition?: 'center' | 'right' | number;
 }
 
 export function SpeechBubble({
   width = 600,
-  height = 300,
   title,
   message,
   visible = true,
+  tailPosition = 'right',
   className,
   style,
   ...props
 }: SpeechBubbleProps) {
+  const calculatedCenter =
+    typeof tailPosition === 'number'
+      ? width / 2 + tailPosition
+      : tailPosition === 'center'
+        ? width / 2
+        : width - 50;
+
+  // Safe bounds: Prevent the tail from drawing outside the bubble's width
+  const tailCenterX = Math.max(35, Math.min(calculatedCenter, width - 35));
+
+  const tailStartX = tailCenterX - 22;
+  const tailEndX = tailCenterX + 20;
+
   return (
     <div
       className={cn(
-        'relative inline-block font-hand transition-all duration-200',
+        'relative flex flex-col items-center justify-end font-hand transition-all duration-200',
         visible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0',
         className
       )}
-      style={{ width: `${width}px`, height: `${height + 34}px`, ...style }}
+      style={{ width: `${width}px`, ...style }}
       {...props}
     >
+      <div
+        className="relative z-10 flex w-full flex-col items-center justify-center bg-white p-4"
+        style={{
+          border: '2.5px solid #2d2d2d',
+          borderRadius: WOBBLY_RADIUS_MD,
+        }}
+      >
+        <div
+          className="mx-auto space-y-2 text-center"
+          style={{ maxWidth: `${Math.max(width - 72, 160)}px` }}
+        >
+          {title && (
+            <p className="font-kalam text-sm font-semibold leading-none text-foreground">
+              {title}
+            </p>
+          )}
+          {message && (
+            <p className="font-hand text-sm leading-snug text-foreground">
+              {message}
+            </p>
+          )}
+        </div>
+      </div>
+
       <svg
         width={width}
-        height={height + 34}
-        viewBox={`0 0 ${width} ${height + 34}`}
+        height={22}
+        viewBox={`0 0 ${width} 22`}
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        className="block"
+        className="pointer-events-none z-20 mt-[-2.5px] block"
       >
-        {/* Main bubble rectangle with wobbly corners */}
-        <rect
-          x="6"
-          y="6"
-          width={width - 12}
-          height={height - 12}
-          fill="#ffffff"
-          stroke="#2d2d2d"
-          strokeWidth="2.5"
-          style={{ borderRadius: WOBBLY_RADIUS_MD }}
-        />
-
         {/* Tail polygon - draws from inside the bubble outward */}
         <path
           d={`
-            M ${width - 72} ${height - 6}
-            L ${width - 50} ${height + 17}
-            L ${width - 30} ${height - 6}
+            M ${tailStartX} 0
+            L ${tailCenterX} 21
+            L ${tailEndX} 0
             Z
           `}
           fill="#ffffff"
@@ -82,14 +112,14 @@ export function SpeechBubble({
 
         {/* Tail border strokes - two separate lines that connect smoothly */}
         <path
-          d={`M ${width - 72} ${height - 6} L ${width - 50} ${height + 17}`}
+          d={`M ${tailStartX} 0 L ${tailCenterX} 21`}
           stroke="#2d2d2d"
           strokeWidth="2.5"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
-          d={`M ${width - 50} ${height + 17} L ${width - 30} ${height - 6}`}
+          d={`M ${tailCenterX} 21 L ${tailEndX} 0`}
           stroke="#2d2d2d"
           strokeWidth="2.5"
           strokeLinecap="round"
@@ -99,37 +129,15 @@ export function SpeechBubble({
         {/* Rhomboid cover to hide the bottom border where tail connects */}
         <path
           d={`
-            M ${width - 72} ${height - 7.5}
-            L ${width - 30} ${height - 7.5}
-            L ${width - 34} ${height - 4.5}
-            L ${width - 68} ${height - 4.5}
+            M ${tailStartX} -2
+            L ${tailEndX} -2
+            L ${tailEndX - 4} 3
+            L ${tailStartX + 4} 3
             Z
           `}
           fill="#ffffff"
         />
       </svg>
-      {(title || message) && (
-        <div
-          className="absolute left-0 top-0 flex items-center justify-center p-4"
-          style={{ width: `${width}px`, height: `${height}px` }}
-        >
-          <div
-            className="mx-auto space-y-2 text-center"
-            style={{ maxWidth: `${Math.max(width - 72, 160)}px` }}
-          >
-            {title && (
-              <p className="font-kalam text-sm font-semibold leading-none text-foreground">
-                {title}
-              </p>
-            )}
-            {message && (
-              <p className="font-hand text-sm leading-snug text-foreground">
-                {message}
-              </p>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Resolves caption display and coordinate detachment issues on gallery memory cards by introducing a dual-system hover overlay: a smooth cinematic vignette, and a hand-drawn speech bubble that dynamically tracks the flexbox layout of the user avatar.

- **Cinematic vignette overlay** in `GalleryMemoryCard.tsx` — Implemented a radial gradient mask with an infinite-fade cinematic style that activates when hovering over a user's profile, presenting captions cleanly over the card geometry.
- **Developer display toggle** in `GalleryMemoryCard.tsx` — Exposed a `USE_SPEECH_BUBBLE` constant to rapidly test and switch between the cinematic gradient and the speech bubble component.
- **Precise tail tracking** in `GalleryMemoryCard.tsx` — Added a continuous `ResizeObserver` attached to the uploader name node. This actively measures font-load widths and dynamically recalculates offset math, ensuring the bubble perfectly points to the circular avatar despite flex row shifts.
- **Dynamic vertical expansion** in `speech-bubble.tsx` — Evolved the bubble's core from a static SVG path into a flexible CSS body bounded by wobbly borders. It natively expands upwards to fit any amount of text content while its bottom anchors precisely to the polaroid.
- **SVG limit clamping** in `speech-bubble.tsx` — Incorporated geometric formulas bounds (`Math.max(35, Math.min(...))`) ensuring the 2.5px tail indicator always stops safely within the bubble's edges, preventing layout tearing on extreme text widths.

### What's intentionally deferred

- Retiring either of the specific overlay modes (cinematic vs bubble). The toggle remains in place so product/design can natively test both layouts on real devices before finalizing the specific UX direction.

### Relation to prior work

Builds on the foundational `GalleryMemoryCard` component. Previous attempts to position absolute tags directly in the polaroid flex hierarchy led to unpredictable tail clipping and drift because flexbox mathematically displaced the avatar based on the length of `uploaderName` text. This update introduces robust ResizeObserver tracking and math, guaranteeing the element floats dead-center while the tail precisely tracks the avatar's X-axis globally.