### PR TITLE
feat: delete user who didn't finish onboarding

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,38 +8,37 @@ datasource db {
 }
 
 model User {
-  id              String          @id @default(uuid()) @db.Uuid
-  studentId       String          @unique @db.VarChar(50)
-  email           String          @unique @db.VarChar(255)
-  firstName       String          @db.VarChar(100)
-  lastName        String          @db.VarChar(100)
-  status          Status          @default(STUDENT)
-  role            UserRole        @default(USER)
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
-  deletedAt       DateTime?
-  // Deactivation: separate from deletedAt; tracks 30-day grace period
-  accountStatus   AccountStatus   @default(ACTIVE)
-  deactivatedAt   DateTime?
-  bio             String?         @db.VarChar(500)
-  phone           String?         @db.VarChar(50)
-  linkedinUrl     String?         @db.VarChar(255)
-  facebookUrl     String?         @db.VarChar(255)
-  contactOther    String?         @db.VarChar(255)
-  avatarUrl       String?         @db.VarChar(500)
-  programBatchId  String          @db.Uuid
-  sentInvitations Invitation[]    @relation("SentInvitations")
-  memories        Memory[]
-  comments        MemoryComment[]
-  votes           MemoryVote[]
-  createdGroups   PrivateGroup[]  @relation("GroupCreator")
-  groupMemberships GroupMembership[]
-  submittedReports Report[]        @relation("ReportReporter")
-  resolvedReports  Report[]        @relation("ReportResolver")
+  id                String                @id @default(uuid()) @db.Uuid
+  studentId         String                @unique @db.VarChar(50)
+  email             String                @unique @db.VarChar(255)
+  firstName         String                @db.VarChar(100)
+  lastName          String                @db.VarChar(100)
+  status            Status                @default(STUDENT)
+  role              UserRole              @default(USER)
+  createdAt         DateTime              @default(now())
+  updatedAt         DateTime              @updatedAt
+  deletedAt         DateTime?
+  programBatchId    String                @db.Uuid
+  avatarUrl         String?               @db.VarChar(500)
+  bio               String?               @db.VarChar(500)
+  contactOther      String?               @db.VarChar(255)
+  facebookUrl       String?               @db.VarChar(255)
+  linkedinUrl       String?               @db.VarChar(255)
+  phone             String?               @db.VarChar(50)
+  accountStatus     AccountStatus         @default(ACTIVE)
+  deactivatedAt     DateTime?
+  groupMemberships  GroupMembership[]
+  sentInvitations   Invitation[]          @relation("SentInvitations")
+  memories          Memory[]
+  comments          MemoryComment[]
+  votes             MemoryVote[]
   moderationActions ModerationActionLog[] @relation("ModerationActionsByAdmin")
-  notifications    Notification[]
-  programBatch    ProgramBatch    @relation(fields: [programBatchId], references: [id])
-  groups          PrivateGroup[]  @relation("GroupMembers")
+  notifications     Notification[]
+  createdGroups     PrivateGroup[]        @relation("GroupCreator")
+  submittedReports  Report[]              @relation("ReportReporter")
+  resolvedReports   Report[]              @relation("ReportResolver")
+  programBatch      ProgramBatch          @relation(fields: [programBatchId], references: [id])
+  groups            PrivateGroup[]        @relation("GroupMembers")
 
   @@index([email])
   @@index([studentId])
@@ -89,33 +88,33 @@ model ProgramBatch {
 }
 
 model Memory {
-  id             String           @id @default(uuid()) @db.Uuid
-  title          String           @db.VarChar(255)
-  description    String?
-  mediaURL       String?          @db.VarChar(2048)
-  mediaURLs      String[]         @default([])
-  uploadDate     DateTime         @default(now())
-  creatorId      String?          @db.Uuid
-  locationId     String           @db.Uuid
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @updatedAt
-  deletedAt      DateTime?
-  isArchived     Boolean          @default(false)
-  visibility     MemoryVisibility @default(PUBLIC)
-  moderationStatus MemoryModerationStatus @default(PENDING)
-  programBatchId String           @db.Uuid
-  privateGroupId String?          @db.Uuid
-  memoryDate     DateTime?
-  creator        User?            @relation(fields: [creatorId], references: [id])
-  location       Location         @relation(fields: [locationId], references: [id])
-  privateGroup   PrivateGroup?    @relation(fields: [privateGroupId], references: [id], onDelete: Restrict)
-  programBatch   ProgramBatch     @relation(fields: [programBatchId], references: [id])
-  comments       MemoryComment[]
-  votes          MemoryVote[]
-  tags           Tag[]            @relation("MemoryTags")
-  reports        Report[]
-  moderationActions ModerationActionLog[] @relation("MemoryModerationActions")
-  notifications  Notification[] @relation("NotificationMemory")
+  id                String                 @id @default(uuid()) @db.Uuid
+  title             String                 @db.VarChar(255)
+  description       String?
+  mediaURL          String?                @db.VarChar(2048)
+  uploadDate        DateTime               @default(now())
+  creatorId         String?                @db.Uuid
+  locationId        String                 @db.Uuid
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
+  deletedAt         DateTime?
+  isArchived        Boolean                @default(false)
+  visibility        MemoryVisibility       @default(PUBLIC)
+  programBatchId    String                 @db.Uuid
+  privateGroupId    String?                @db.Uuid
+  memoryDate        DateTime?
+  moderationStatus  MemoryModerationStatus @default(PENDING)
+  mediaURLs         String[]               @default([])
+  creator           User?                  @relation(fields: [creatorId], references: [id])
+  location          Location               @relation(fields: [locationId], references: [id])
+  privateGroup      PrivateGroup?          @relation(fields: [privateGroupId], references: [id], onDelete: Restrict)
+  programBatch      ProgramBatch           @relation(fields: [programBatchId], references: [id])
+  comments          MemoryComment[]
+  votes             MemoryVote[]
+  moderationActions ModerationActionLog[]  @relation("MemoryModerationActions")
+  notifications     Notification[]         @relation("NotificationMemory")
+  reports           Report[]
+  tags              Tag[]                  @relation("MemoryTags")
 
   @@index([creatorId])
   @@index([programBatchId])
@@ -161,21 +160,21 @@ model MemoryVote {
 }
 
 model Report {
-  id               String     @id @default(uuid()) @db.Uuid
-  state            ReportState @default(OPEN)
-  reason           String
-  reporterId       String     @db.Uuid
-  memoryId         String     @db.Uuid
-  resolvedById     String?    @db.Uuid
-  resolutionNote   String?
-  createdAt        DateTime   @default(now())
-  updatedAt        DateTime   @updatedAt
-  resolvedAt       DateTime?
-  reporter         User       @relation("ReportReporter", fields: [reporterId], references: [id], onDelete: Cascade)
-  memory           Memory     @relation(fields: [memoryId], references: [id], onDelete: Cascade)
-  resolvedBy       User?      @relation("ReportResolver", fields: [resolvedById], references: [id], onDelete: SetNull)
+  id                String                @id @default(uuid()) @db.Uuid
+  state             ReportState           @default(OPEN)
+  reason            String
+  reporterId        String                @db.Uuid
+  memoryId          String                @db.Uuid
+  resolvedById      String?               @db.Uuid
+  resolutionNote    String?
+  createdAt         DateTime              @default(now())
+  updatedAt         DateTime              @updatedAt
+  resolvedAt        DateTime?
   moderationActions ModerationActionLog[] @relation("ReportModerationActions")
-  notifications    Notification[] @relation("NotificationReport")
+  notifications     Notification[]        @relation("NotificationReport")
+  memory            Memory                @relation(fields: [memoryId], references: [id], onDelete: Cascade)
+  reporter          User                  @relation("ReportReporter", fields: [reporterId], references: [id], onDelete: Cascade)
+  resolvedBy        User?                 @relation("ReportResolver", fields: [resolvedById], references: [id])
 
   @@index([state])
   @@index([reporterId])
@@ -193,9 +192,9 @@ model ModerationActionLog {
   targetReportId String?              @db.Uuid
   reason         String?
   createdAt      DateTime             @default(now())
-  admin          User                 @relation("ModerationActionsByAdmin", fields: [adminId], references: [id], onDelete: Restrict)
-  targetMemory   Memory?              @relation("MemoryModerationActions", fields: [targetMemoryId], references: [id], onDelete: SetNull)
-  targetReport   Report?              @relation("ReportModerationActions", fields: [targetReportId], references: [id], onDelete: SetNull)
+  admin          User                 @relation("ModerationActionsByAdmin", fields: [adminId], references: [id])
+  targetMemory   Memory?              @relation("MemoryModerationActions", fields: [targetMemoryId], references: [id])
+  targetReport   Report?              @relation("ReportModerationActions", fields: [targetReportId], references: [id])
 
   @@index([adminId])
   @@index([action])
@@ -232,20 +231,20 @@ model Tag {
 }
 
 model PrivateGroup {
-  id          String       @id @default(uuid()) @db.Uuid
-  name        String       @unique @db.VarChar(50)
-  description String?
-  message     String?      @db.VarChar(300)
-  rolePrivileges Json?
-  creatorId   String?      @db.Uuid
-  deletedAt   DateTime?
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  invitations Invitation[]
-  memories    Memory[]
-  creator     User?        @relation("GroupCreator", fields: [creatorId], references: [id])
-  members     User[]       @relation("GroupMembers")
+  id               String            @id @default(uuid()) @db.Uuid
+  name             String            @unique @db.VarChar(50)
+  description      String?
+  creatorId        String?           @db.Uuid
+  deletedAt        DateTime?
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  rolePrivileges   Json?
+  message          String?           @db.VarChar(300)
   groupMemberships GroupMembership[]
+  invitations      Invitation[]
+  memories         Memory[]
+  creator          User?             @relation("GroupCreator", fields: [creatorId], references: [id])
+  members          User[]            @relation("GroupMembers")
 
   @@index([name])
   @@index([creatorId])
@@ -275,17 +274,46 @@ model Invitation {
   invitedBy String       @db.Uuid
   email     String?      @db.VarChar(255)
   token     String       @unique @db.VarChar(64)
-  isForAll  Boolean      @default(false)
-  maxUses   Int          @default(1)
   expiresAt DateTime
   createdAt DateTime     @default(now())
+  isForAll  Boolean      @default(false)
+  maxUses   Int          @default(1)
   group     PrivateGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  inviter   User         @relation("SentInvitations", fields: [invitedBy], references: [id])
+  inviter   User         @relation("SentInvitations", fields: [invitedBy], references: [id], onDelete: Cascade)
 
   @@index([token])
   @@index([groupId])
   @@index([email])
   @@index([expiresAt])
+}
+
+model Notification {
+  id             String           @id @default(uuid()) @db.Uuid
+  userId         String           @db.Uuid
+  type           NotificationType
+  title          String           @db.VarChar(255)
+  message        String
+  targetMemoryId String?          @db.Uuid
+  targetReportId String?          @db.Uuid
+  reason         String?
+  read           Boolean          @default(false)
+  createdAt      DateTime         @default(now())
+  targetMemory   Memory?          @relation("NotificationMemory", fields: [targetMemoryId], references: [id])
+  targetReport   Report?          @relation("NotificationReport", fields: [targetReportId], references: [id])
+  user           User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, read])
+  @@index([userId, createdAt])
+  @@index([targetMemoryId])
+  @@index([targetReportId])
+}
+
+model UploadRateLimit {
+  id        String   @id @default(uuid()) @db.Uuid
+  userId    String   @db.Uuid
+  createdAt DateTime @default(now())
+
+  @@index([userId, createdAt])
 }
 
 enum Status {
@@ -340,7 +368,6 @@ enum ModerationTargetType {
   REPORT
 }
 
-// Tracks whether an account is active or in the 30-day deactivation grace period
 enum AccountStatus {
   ACTIVE
   DEACTIVATED
@@ -352,34 +379,4 @@ enum NotificationType {
   MEMORY_REMOVED
   REPORT_RESOLVED
   REPORT_DISMISSED
-}
-
-model Notification {
-  id             String           @id @default(uuid()) @db.Uuid
-  userId         String           @db.Uuid
-  type           NotificationType
-  title          String           @db.VarChar(255)
-  message        String
-  targetMemoryId String?          @db.Uuid
-  targetReportId String?          @db.Uuid
-  reason         String?
-  read           Boolean          @default(false)
-  createdAt      DateTime         @default(now())
-
-  user         User    @relation(fields: [userId], references: [id], onDelete: Cascade)
-  targetMemory Memory? @relation("NotificationMemory", fields: [targetMemoryId], references: [id], onDelete: SetNull)
-  targetReport Report? @relation("NotificationReport", fields: [targetReportId], references: [id], onDelete: SetNull)
-
-  @@index([userId, read])
-  @@index([userId, createdAt])
-  @@index([targetMemoryId])
-  @@index([targetReportId])
-}
-
-model UploadRateLimit {
-  id        String   @id @default(uuid()) @db.Uuid
-  userId    String   @db.Uuid
-  createdAt DateTime @default(now())
-
-  @@index([userId, createdAt])
 }

--- a/src/app/api/prisma/user/delete/route.ts
+++ b/src/app/api/prisma/user/delete/route.ts
@@ -5,9 +5,9 @@ import { NextResponse } from 'next/server';
 /**
  * DELETE /api/prisma/user/delete
  *
- * Performs a cascading soft-delete: sets `deletedAt` on the authenticated User
- * and on every Memory record they created, all within a single Prisma
- * transaction to guarantee data consistency.
+ * Handles user deletion:
+ * - If user is not onboarded, just delete the auth user via raw SQL.
+ * - If user is onboarded, delete auth user via raw SQL first, then delete the matching public user via Prisma.
  */
 export async function DELETE() {
   try {
@@ -20,20 +20,24 @@ export async function DELETE() {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
-    const now = new Date();
+    // Check the user_onboarded flag in the auth table (stored in app_metadata)
+    const isOnboarded = authUser.app_metadata?.onboarded === true;
 
-    await prisma.$transaction([
-      // Soft-delete all Memory records owned by this user
-      prisma.memory.updateMany({
-        where: { creatorId: authUser.id, deletedAt: null },
-        data: { deletedAt: now },
-      }),
-      // Soft-delete the User record
-      prisma.user.update({
+    if (!isOnboarded) {
+      // User never finished onboarding, just delete the auth user via raw SQL
+      await prisma.$executeRaw`DELETE FROM auth.users WHERE id = ${authUser.id}::uuid`;
+    } else {
+      // User is fully onboarded, delete auth user via raw SQL first
+      await prisma.$executeRaw`DELETE FROM auth.users WHERE id = ${authUser.id}::uuid`;
+
+      // Then delete the matching public user via Prisma
+      await prisma.user.delete({
         where: { id: authUser.id },
-        data: { deletedAt: now },
-      }),
-    ]);
+      });
+    }
+
+    // Sign out to clear session cookies
+    await supabase.auth.signOut();
 
     return NextResponse.json({
       success: true,
@@ -41,6 +45,7 @@ export async function DELETE() {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[user/delete] Error:', message);
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { ChevronRight } from 'lucide-react';
 import { useOnboardUser } from '@/lib/hooks/useOnboardUser';
 import { useUserAuth } from '@/lib/hooks/useUserAuth';
+import { useDeleteUser } from '@/lib/hooks/useDeleteUser';
 import { Header } from '@/components/header';
 import { BatchSelectorModal } from '@/components/onboarding/batch-selector-modal';
 import { CourseSelectorModal } from '@/components/onboarding/course-selector-modal';
@@ -32,6 +33,7 @@ function OnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const onboardUser = useOnboardUser();
+  const deleteUser = useDeleteUser();
   const { user } = useUserAuth();
 
   // After onboarding, redirect to the original page (e.g. /invite?token=...)
@@ -200,10 +202,19 @@ function OnboardingContent() {
             </a>
             <div className="flex gap-2">
               <button
-                onClick={() => router.push('/')}
-                className="bg-secondary px-4 py-1.5 text-xs font-medium text-foreground transition hover:bg-secondary/80"
+                disabled={deleteUser.isPending}
+                onClick={async () => {
+                  try {
+                    await deleteUser.mutateAsync();
+                  } catch (err) {
+                    console.error('Failed to delete user:', err);
+                  } finally {
+                    router.push('/');
+                  }
+                }}
+                className="bg-secondary px-4 py-1.5 text-xs font-medium text-foreground transition hover:bg-secondary/80 disabled:opacity-50"
               >
-                Back
+                {deleteUser.isPending ? 'Going back...' : 'Back'}
               </button>
               <button
                 disabled={!allCompleted || onboardUser.isPending}
@@ -226,13 +237,14 @@ function OnboardingContent() {
                       studentId,
                       status,
                     });
-                    router.push(redirectTo);
                   } catch (err) {
                     setOnboardError(
                       err instanceof Error
                         ? err.message
                         : 'Something went wrong'
                     );
+                  } finally {
+                    router.push(redirectTo);
                   }
                 }}
                 className={`px-4 py-1.5 text-xs font-medium text-white transition ${

--- a/src/lib/hooks/useDeleteUser.ts
+++ b/src/lib/hooks/useDeleteUser.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+interface DeleteUserResponse {
+  success: boolean;
+  message: string;
+}
+
+export function useDeleteUser() {
+  return useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/prisma/user/delete', {
+        method: 'DELETE',
+      });
+
+      const body = await res.json();
+
+      if (!res.ok) {
+        throw new Error(
+          (body as { error?: string }).error ?? 'Failed to delete user'
+        );
+      }
+
+      return body as DeleteUserResponse;
+    },
+  });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,7 +11,11 @@ const PUBLIC_ROUTES = [
 ];
 
 /** Routes accessible to authenticated-but-not-onboarded users. */
-const ONBOARDING_ROUTES = ['/onboarding', '/api/prisma/user/create'];
+const ONBOARDING_ROUTES = [
+  '/onboarding',
+  '/api/prisma/user/create',
+  '/api/prisma/user/delete',
+];
 
 function matchesRoute(pathname: string, routes: string[]) {
   return routes.some(


### PR DESCRIPTION
Fix issue where dangling auth users are left after onboarding cancellation. From now on, when users cancel onboarding, their auth data is deleted.