### PR TITLE
feat: guard admin route

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { requireAdmin } from '@/lib/utils/require-admin';
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const result = await requireAdmin();
+
+  if ('error' in result) {
+    redirect('/');
+  }
+
+  return children;
+}


### PR DESCRIPTION
Add an admin layout that calls requireAdmin() before rendering. Redirect non-admin users away from /admin to prevent direct URL access.