### PR TITLE
UI uniformity fix 2

### DIFF
--- a/src/components/announcement-strips/AboutAnnouncementStrip.tsx
+++ b/src/components/announcement-strips/AboutAnnouncementStrip.tsx
@@ -15,7 +15,7 @@ export function AboutAnnouncementStrip({
       <AnnouncementMarqueeTrack
         announcements={announcements}
         ariaLabel="About page announcements"
-        itemClassName="flex shrink-0 items-center gap-4 px-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
+        itemClassName="flex shrink-0 items-center gap-4 pr-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
         separatorClassName="text-black/70"
       />
     </div>

--- a/src/components/announcement-strips/AdminAnnouncementStrip.tsx
+++ b/src/components/announcement-strips/AdminAnnouncementStrip.tsx
@@ -15,7 +15,7 @@ export function AdminAnnouncementStrip({
       <AnnouncementMarqueeTrack
         announcements={announcements}
         ariaLabel="Admin announcements"
-        itemClassName="flex shrink-0 items-center gap-4 px-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
+        itemClassName="flex shrink-0 items-center gap-4 pr-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
         separatorClassName="text-black/70"
       />
     </div>

--- a/src/components/announcement-strips/GalleryAnnouncementStrip.tsx
+++ b/src/components/announcement-strips/GalleryAnnouncementStrip.tsx
@@ -15,7 +15,7 @@ export function GalleryAnnouncementStrip({
       <AnnouncementMarqueeTrack
         announcements={announcements}
         ariaLabel="Gallery announcements"
-        itemClassName="flex shrink-0 items-center gap-4 px-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
+        itemClassName="flex shrink-0 items-center gap-4 pr-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
         separatorClassName="text-black/70"
       />
     </div>

--- a/src/components/announcement-strips/MapAnnouncementStrip.tsx
+++ b/src/components/announcement-strips/MapAnnouncementStrip.tsx
@@ -15,7 +15,7 @@ export function MapAnnouncementStrip({
       <AnnouncementMarqueeTrack
         announcements={announcements}
         ariaLabel="Map announcements"
-        itemClassName="flex shrink-0 items-center gap-4 px-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
+        itemClassName="flex shrink-0 items-center gap-4 pr-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
         separatorClassName="text-black/70"
       />
     </div>

--- a/src/components/announcement-strips/ProfileAnnouncementStrip.tsx
+++ b/src/components/announcement-strips/ProfileAnnouncementStrip.tsx
@@ -15,7 +15,7 @@ export function ProfileAnnouncementStrip({
       <AnnouncementMarqueeTrack
         announcements={announcements}
         ariaLabel="Profile announcements"
-        itemClassName="flex shrink-0 items-center gap-4 px-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
+        itemClassName="flex shrink-0 items-center gap-4 pr-4 text-xs font-semibold uppercase tracking-[0.14em] text-black sm:text-sm"
         separatorClassName="text-black/70"
       />
     </div>

--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -341,7 +341,7 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
       )}
       <div
         className={cn(
-          'pointer-events-none absolute left-1/2 z-[60] flex w-[calc(100%-1.5rem)] -translate-x-1/2 justify-center transition-[top,bottom,transform] duration-300 ease-out sm:w-[calc(100%-2.5rem)]',
+          'pointer-events-none absolute left-1/2 z-[60] flex w-[calc(100vw-1rem)] -translate-x-1/2 justify-center transition-[top,bottom,transform] duration-300 ease-out md:w-[70vw]',
           open
             ? 'bottom-[5.5rem] sm:bottom-auto sm:top-[47%] sm:-translate-y-1/2'
             : 'bottom-0',

--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -341,7 +341,7 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
       )}
       <div
         className={cn(
-          'pointer-events-none absolute left-1/2 z-20 flex w-[calc(100%-1.5rem)] -translate-x-1/2 justify-center transition-[top,bottom,transform] duration-300 ease-out sm:w-[calc(100%-2.5rem)]',
+          'pointer-events-none absolute left-1/2 z-[60] flex w-[calc(100%-1.5rem)] -translate-x-1/2 justify-center transition-[top,bottom,transform] duration-300 ease-out sm:w-[calc(100%-2.5rem)]',
           open
             ? 'bottom-[5.5rem] sm:bottom-auto sm:top-[47%] sm:-translate-y-1/2'
             : 'bottom-0',

--- a/src/components/map/FilterPanel.tsx
+++ b/src/components/map/FilterPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { X, RotateCcw, Filter } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
@@ -54,6 +55,50 @@ export function FilterPanel({
 }: FilterPanelProps) {
   usePanelOpenEffects(open);
 
+  const [btnAnim, setBtnAnim] = useState<
+    'idle' | 'bob-open' | 'submerged' | 'bounce-back'
+  >('idle');
+  const prevOpenRef = useRef(open);
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const bounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  // Synchronously mark button as submerged before paint so there's no flash
+  // when the panel closes and the button re-enters the DOM.
+  useLayoutEffect(() => {
+    if (prevOpenRef.current && !open) {
+      setBtnAnim('submerged');
+    }
+    prevOpenRef.current = open;
+  }, [open]);
+
+  // After the panel has finished sliding down, surface the button.
+  useEffect(() => {
+    if (!open) {
+      bounceTimerRef.current = setTimeout(() => {
+        setBtnAnim('bounce-back');
+        setTimeout(() => setBtnAnim('idle'), 500);
+      }, 300);
+      return () => clearTimeout(bounceTimerRef.current);
+    }
+  }, [open]);
+
+  const handleTabClick = () => {
+    if (open) {
+      onOpenChange(false);
+      return;
+    }
+    setBtnAnim('bob-open');
+    clearTimeout(openTimerRef.current);
+    openTimerRef.current = setTimeout(() => {
+      onOpenChange(true);
+      setBtnAnim('submerged');
+    }, 400);
+  };
+
   const update = <K extends keyof MemoryFilters>(
     key: K,
     value: MemoryFilters[K]
@@ -84,10 +129,12 @@ export function FilterPanel({
         <button
           type="button"
           aria-label={open ? 'Close filters' : 'Open filters'}
-          onClick={() => onOpenChange(!open)}
+          onClick={handleTabClick}
           className={cn(
-            'pointer-events-auto absolute -top-[4.5rem] left-4 h-[4.5rem] w-10 flex-col items-center justify-start gap-1 border-2 border-b-0 border-[#1f1f1f] bg-[#f6cb48] pt-2 text-black transition-transform duration-200 ease-out',
-            open ? 'hidden sm:flex' : 'flex'
+            'pointer-events-auto absolute -top-[4.5rem] left-4 h-[4.5rem] w-10 flex-col items-center justify-start gap-1 border-2 border-b-0 border-[#1f1f1f] bg-[#f6cb48] pt-2 text-black',
+            open || btnAnim === 'submerged' ? 'hidden' : 'flex',
+            btnAnim === 'bob-open' && 'animate-btn-bob-open',
+            btnAnim === 'bounce-back' && 'animate-btn-bounce-back'
           )}
         >
           <Filter className="h-3 w-3 stroke-[2.5]" aria-hidden />

--- a/src/components/map/FilterPanel.tsx
+++ b/src/components/map/FilterPanel.tsx
@@ -114,9 +114,11 @@ export function FilterPanel({
   return (
     <div
       className={cn(
-        'pointer-events-none absolute left-1/2 z-20 flex w-fit -translate-x-1/2 justify-center transition-[bottom,transform] duration-300 ease-out',
+        'pointer-events-none absolute left-1/2 z-20 flex w-fit -translate-x-1/2 justify-center transition-[bottom,top,transform] duration-300 ease-out',
         open && 'pointer-events-auto',
-        open ? 'bottom-[5.5rem] sm:bottom-12' : 'bottom-0'
+        open
+          ? 'bottom-[5.5rem] sm:bottom-auto sm:top-1/2 sm:-translate-y-1/2'
+          : 'bottom-0'
       )}
     >
       <section

--- a/src/components/shared/shell/main-shell.tsx
+++ b/src/components/shared/shell/main-shell.tsx
@@ -538,12 +538,12 @@ function ShellSidebarLayout({
   return (
     <aside
       className={`relative z-40 flex h-full flex-col overflow-hidden bg-white text-foreground transition-all duration-300 ease-in-out ${
-        isOpen ? 'w-52 sm:w-64' : 'w-0'
+        isOpen ? 'w-60 sm:w-72' : 'w-0'
       }`}
     >
       <div className="flex items-center px-4 pb-6 pt-6">
         <div
-          className={`flex justify-center overflow-hidden transition-all duration-300 ease-in-out ${
+          className={`flex justify-start transition-all duration-300 ease-in-out ${
             isOpen ? 'max-w-[220px] opacity-100' : 'max-w-0 opacity-0'
           }`}
         >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,9 +63,37 @@ export default {
           '0%': { opacity: '0', transform: 'translate(-50%, -1rem)' },
           '100%': { opacity: '1', transform: 'translate(-50%, 0)' },
         },
+        btnBobOpen: {
+          '0%': {
+            transform: 'translateY(0)',
+            opacity: '1',
+            animationTimingFunction: 'ease-in',
+          },
+          '8%': {
+            transform: 'translateY(4px)',
+            opacity: '1',
+            animationTimingFunction: 'ease-out',
+          },
+          '22%': {
+            transform: 'translateY(-14px)',
+            opacity: '1',
+            animationTimingFunction: 'ease-in',
+          },
+          '78%': { transform: 'translateY(60px)', opacity: '1' },
+          '100%': { transform: 'translateY(76px)', opacity: '0' },
+        },
+        btnBounceBack: {
+          '0%': { transform: 'translateY(72px)', opacity: '0' },
+          '45%': { transform: 'translateY(-15px)', opacity: '1' },
+          '65%': { transform: 'translateY(3px)', opacity: '1' },
+          '82%': { transform: 'translateY(-8px)', opacity: '1' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
+        },
       },
       animation: {
         'slide-down': 'slideDown 0.35s ease-out',
+        'btn-bob-open': 'btnBobOpen 0.4s ease-in both',
+        'btn-bounce-back': 'btnBounceBack 0.5s ease-out both',
       },
     },
   },


### PR DESCRIPTION
## Summary
- Removed non-functional "Need Help" and "More info" buttons from onboarding
- Restructured ProfileHero layout so the badge strip (including student ID) always has full width; student ID badge added
- Removed `max-w-[48ch]` constraint on card header descriptions across all profile panels
- Fixed group panel z-index (`z-20` → `z-[60]`) so clicks reach the panel instead of the backdrop overlay
- Corrected announcement strip padding (`px-4` → `pr-4`) and sidebar logo alignment (`justify-center` → `justify-start`)
- Added sequenced tab animation to the filter panel: press-down → spring up → sink and fade on open; surface from below with bounce-back on close