### PR TITLE
Dev

### DIFF
--- a/src/app/gallery/gallery-client.tsx
+++ b/src/app/gallery/gallery-client.tsx
@@ -26,8 +26,26 @@ export default function GalleryPageClient() {
   );
   const { data: response, isLoading, error } = useAllMemoriesWithCoordinates();
   const visibleMemories = useMemo(() => {
-    const eraMemories = filterMemoriesByEra(response?.data ?? [], activeEra);
-    const filteredMemories = applyMemoryFilters(eraMemories, filters);
+    const all = response?.data ?? [];
+    let scoped;
+    if (filters.selectedYear) {
+      // Year overrides era — filter from global set
+      scoped = all.filter((m) => {
+        if (
+          m.moderationStatus === 'REJECTED' ||
+          m.moderationStatus === 'REMOVED'
+        )
+          return false;
+        const dv = (m as { memoryDate?: string }).memoryDate;
+        const y = dv
+          ? new Date(dv).getFullYear()
+          : new Date(m.createdAt ?? Date.now()).getFullYear();
+        return y === filters.selectedYear;
+      });
+    } else {
+      scoped = filterMemoriesByEra(all, activeEra);
+    }
+    const filteredMemories = applyMemoryFilters(scoped, filters);
     return sortMemories(filteredMemories, filters.sortBy);
   }, [activeEra, filters, response?.data]);
   const mapHrefBase = useMemo(

--- a/src/app/map/map-client.tsx
+++ b/src/app/map/map-client.tsx
@@ -58,6 +58,28 @@ export default function MapPageClient() {
     [router, searchParams]
   );
 
+  const handleEraChange = useCallback(
+    (era: number) => {
+      const nextParams = new URLSearchParams(searchParams.toString());
+      nextParams.set('era', String(era));
+      // Clear year override and dependent filters atomically
+      nextParams.delete('year');
+      nextParams.delete('tags');
+      nextParams.delete('locationId');
+
+      const nextSearch = nextParams.toString();
+      const nextUrl = nextSearch ? `/map?${nextSearch}` : '/map';
+      const currentUrl = `/map${
+        searchParams.toString() ? `?${searchParams.toString()}` : ''
+      }`;
+
+      if (nextUrl !== currentUrl) {
+        router.replace(nextUrl, { scroll: false });
+      }
+    },
+    [router, searchParams]
+  );
+
   return (
     <div className="relative h-dvh overflow-hidden bg-background">
       <div className="h-full min-w-0 overflow-hidden">
@@ -65,6 +87,7 @@ export default function MapPageClient() {
           activeEraFromUrl={activeEra}
           filters={filters}
           onFiltersChange={setFilters}
+          onEraChange={handleEraChange}
         />
       </div>
     </div>

--- a/src/components/groups/CreateGroupModal.tsx
+++ b/src/components/groups/CreateGroupModal.tsx
@@ -1,26 +1,11 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/Dialog';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
-import { WOBBLY_RADIUS_MD } from '@/lib/hand-drawn';
-import {
-  Globe,
-  Lock,
-  Eye,
-  EyeOff,
-  ChevronDown,
-  Mail,
-  Info,
-  Loader2,
-} from 'lucide-react';
-import {
-  type GroupPrivacy,
-  type GroupVisibility,
-  createGroupSchema,
-} from '@/lib/types/group';
+import { Mail, Loader2 } from 'lucide-react';
 import { useCreateGroup, type GroupResponse } from '@/lib/hooks/useCreateGroup';
 
 // ─── PROPS ──────────────────────────────────────────────────────────
@@ -33,159 +18,6 @@ interface CreateGroupModalProps {
   onCreated: (group: GroupResponse) => void;
 }
 
-// ─── CUSTOM DROPDOWN COMPONENT ──────────────────────────────────────
-
-interface DropdownOption<T extends string> {
-  value: T;
-  label: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-interface CustomDropdownProps<T extends string> {
-  label: string;
-  tooltip: string;
-  options: DropdownOption<T>[];
-  value: T;
-  onChange: (value: T) => void;
-}
-
-function CustomDropdown<T extends string>({
-  label,
-  tooltip,
-  options,
-  value,
-  onChange,
-}: CustomDropdownProps<T>) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [showTooltip, setShowTooltip] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const selected = options.find((o) => o.value === value);
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-1.5">
-        <Label>{label}</Label>
-        <div
-          className="relative"
-          onMouseEnter={() => setShowTooltip(true)}
-          onMouseLeave={() => setShowTooltip(false)}
-        >
-          <Info size={14} className="cursor-help text-muted-foreground" />
-          {showTooltip && (
-            <div
-              className="absolute bottom-full left-1/2 z-30 mb-2 w-56 -translate-x-1/2 border-2 border-border bg-card px-3 py-2 text-xs text-muted-foreground shadow-[3px_3px_0px_0px_#2d2d2d]"
-              style={{ borderRadius: WOBBLY_RADIUS_MD }}
-            >
-              {tooltip}
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div ref={dropdownRef} className="relative">
-        <button
-          type="button"
-          onClick={() => setIsOpen(!isOpen)}
-          className="flex w-full items-center justify-between border-2 border-input bg-transparent px-3 py-2 text-sm transition-colors hover:bg-secondary"
-        >
-          <span className="flex items-center gap-2">
-            {selected?.icon}
-            <span>{selected?.label}</span>
-          </span>
-          <ChevronDown
-            size={16}
-            className={`text-muted-foreground transition-transform ${isOpen ? 'rotate-180' : ''}`}
-          />
-        </button>
-
-        {isOpen && (
-          <div
-            className="absolute left-0 top-full z-20 mt-1 w-full overflow-hidden border-2 border-border bg-card shadow-[3px_3px_0px_0px_#2d2d2d]"
-            style={{ borderRadius: WOBBLY_RADIUS_MD }}
-          >
-            {options.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => {
-                  onChange(option.value);
-                  setIsOpen(false);
-                }}
-                className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary ${
-                  value === option.value
-                    ? 'border-l-2 border-skolaroid-blue bg-skolaroid-blue/5'
-                    : 'border-l-2 border-transparent'
-                }`}
-              >
-                <span className="mt-0.5 shrink-0 text-skolaroid-blue">
-                  {option.icon}
-                </span>
-                <span>
-                  <span className="block text-sm font-semibold text-foreground">
-                    {option.label}
-                  </span>
-                  <span className="mt-0.5 block text-xs leading-relaxed text-muted-foreground">
-                    {option.description}
-                  </span>
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ─── PRIVACY/VISIBILITY OPTIONS ─────────────────────────────────────
-
-const privacyOptions: DropdownOption<GroupPrivacy>[] = [
-  {
-    value: 'PUBLIC',
-    label: 'Public',
-    description:
-      "Anyone can see who's in the group and what they post. Depending on your group's size and age, you might be able to change to private later.",
-    icon: <Globe size={20} />,
-  },
-  {
-    value: 'PRIVATE',
-    label: 'Private',
-    description:
-      "Only members can see who's in the group and what they post. You might be able to change to public later.",
-    icon: <Lock size={20} />,
-  },
-];
-
-const visibilityOptions: DropdownOption<GroupVisibility>[] = [
-  {
-    value: 'VISIBLE',
-    label: 'Visible',
-    description: 'Anyone can find this group.',
-    icon: <Eye size={20} />,
-  },
-  {
-    value: 'HIDDEN',
-    label: 'Hidden',
-    description: 'Only members can find this group.',
-    icon: <EyeOff size={20} />,
-  },
-];
-
 // ─── MAIN COMPONENT ─────────────────────────────────────────────────
 
 export function CreateGroupModal({
@@ -195,8 +27,6 @@ export function CreateGroupModal({
 }: CreateGroupModalProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [privacy, setPrivacy] = useState<GroupPrivacy>('PUBLIC');
-  const [visibility, setVisibility] = useState<GroupVisibility>('VISIBLE');
   const [inviteEmails, setInviteEmails] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
   const createGroup = useCreateGroup();
@@ -204,8 +34,6 @@ export function CreateGroupModal({
   const resetForm = useCallback(() => {
     setName('');
     setDescription('');
-    setPrivacy('PUBLIC');
-    setVisibility('VISIBLE');
     setInviteEmails('');
     setErrors({});
   }, []);
@@ -239,23 +67,13 @@ export function CreateGroupModal({
   };
 
   const handleSubmit = () => {
-    const result = createGroupSchema.safeParse({
-      name,
-      description: description || undefined,
-      privacy,
-      visibility,
-      inviteEmails,
-    });
-
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {};
-      for (const issue of result.error.issues) {
-        const field = issue.path[0] as string;
-        if (!fieldErrors[field]) {
-          fieldErrors[field] = issue.message;
-        }
-      }
-      setErrors(fieldErrors);
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setErrors({ name: 'Group name is required' });
+      return;
+    }
+    if (trimmedName.length > 100) {
+      setErrors({ name: 'Group name must be 100 characters or less' });
       return;
     }
 
@@ -345,25 +163,7 @@ export function CreateGroupModal({
               </p>
             </div>
 
-            {/* Field 3 — Choose Privacy */}
-            <CustomDropdown
-              label="Choose Privacy"
-              tooltip="Privacy controls who can see group content and members."
-              options={privacyOptions}
-              value={privacy}
-              onChange={setPrivacy}
-            />
-
-            {/* Field 4 — Choose Visibility */}
-            <CustomDropdown
-              label="Choose Visibility"
-              tooltip="Visibility controls whether people can find this group in search."
-              options={visibilityOptions}
-              value={visibility}
-              onChange={setVisibility}
-            />
-
-            {/* Field 5 — Invite Users */}
+            {/* Field 3 — Invite Users */}
             <div className="space-y-2">
               <Label>
                 Invite Members{' '}

--- a/src/components/groups/GroupPanel.tsx
+++ b/src/components/groups/GroupPanel.tsx
@@ -12,12 +12,9 @@ import { createPortal } from 'react-dom';
 import { GroupSwitcher, useGroupToast } from '@/components/groups';
 import { usePanelOpenEffects } from '@/components/shared/shell/MainShellSidebarAction';
 import { CreateGroupModal } from '@/components/groups/CreateGroupModal';
-import { InviteMembersModal } from '@/components/groups/InviteMembersModal';
 import { ShareGroupModal } from '@/components/groups/ShareGroupModal';
 import { LeaveGroupModal } from '@/components/groups/LeaveGroupModal';
 import { DeleteGroupModal } from '@/components/groups/DeleteGroupModal';
-import { EditGroupModal } from '@/components/groups/EditGroupModal';
-import { EditGroupMessageModal } from '@/components/groups/EditGroupMessageModal';
 import { MembersTab } from '@/components/groups/tabs/MembersTab';
 import { MediaTab } from '@/components/groups/tabs/MediaTab';
 import { AboutTab } from '@/components/groups/tabs/AboutTab';
@@ -41,35 +38,24 @@ import {
 import { cn } from '@/lib/utils';
 import {
   X,
-  MoreHorizontal,
   Users,
   Image as ImageIcon,
   Info,
   Settings,
-  UserPlus,
   Share2,
-  Trash2,
   LogOut,
   Globe,
   Lock,
   Loader2,
   Shield,
-  Pencil,
-  MessageSquare,
 } from 'lucide-react';
 import { BookmarkSimpleIcon } from '@phosphor-icons/react';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from '@/components/ui/DropdownMenu';
 import { Badge } from '@/components/ui/Badge';
 
 interface GroupPanelProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onSelectedGroupChange?: (groupId: string | null) => void;
 }
 
 type TabType = 'members' | 'media' | 'settings' | 'about' | 'roles';
@@ -123,15 +109,16 @@ function toGroup(g: GroupResponse): Group {
   };
 }
 
-export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
+export function GroupPanel({
+  open,
+  onOpenChange,
+  onSelectedGroupChange,
+}: GroupPanelProps) {
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [createModalOpen, setCreateModalOpen] = useState(false);
-  const [inviteModalOpen, setInviteModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [leaveModalOpen, setLeaveModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [editGroupModalOpen, setEditGroupModalOpen] = useState(false);
-  const [editMessageModalOpen, setEditMessageModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType>('members');
 
   const [btnAnim, setBtnAnim] = useState<
@@ -233,6 +220,11 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
     }
   }, [groups, selectedGroupId]);
 
+  // Notify parent when selected group changes
+  useEffect(() => {
+    onSelectedGroupChange?.(selectedGroupId);
+  }, [selectedGroupId, onSelectedGroupChange]);
+
   // Build the selected group from either the detail query or the list
   const selectedGroup: Group | null = useMemo(() => {
     if (groupDetailRaw) return toGroup(groupDetailRaw);
@@ -254,13 +246,6 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const canManageMembers =
     !!selectedGroup &&
     canRoleUsePermission(rolePrivileges, currentUserRole, 'manageMembers');
-  const canSendInvitations =
-    !!selectedGroup &&
-    canRoleUsePermission(rolePrivileges, currentUserRole, 'sendInvitations');
-  const canEditMessage =
-    !!selectedGroup &&
-    (currentUserRole === 'OWNER' || currentUserRole === 'ADMIN');
-  const hasMoreActions = isOwner || canSendInvitations || canEditMessage;
 
   // ─── Handlers ────────────────────────────────────────────────────
   const handleSelectGroup = useCallback((group: Group) => {
@@ -352,16 +337,6 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
   const handlePrivilegesSaved = useCallback(() => {
     refetchGroupDetail();
     showSuccess('Role privileges updated successfully.');
-  }, [refetchGroupDetail, showSuccess]);
-
-  const handleGroupUpdated = useCallback(() => {
-    refetchGroupDetail();
-    showSuccess('Group updated successfully.');
-  }, [refetchGroupDetail, showSuccess]);
-
-  const handleMessageUpdated = useCallback(() => {
-    refetchGroupDetail();
-    showSuccess('Group message updated.');
   }, [refetchGroupDetail, showSuccess]);
 
   const openNestedModal = useCallback(
@@ -495,8 +470,8 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
             </div>
           </div>
 
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            <div className="overflow-x-auto border-b-[2px] border-black px-2 py-2 sm:px-3 sm:py-3">
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="border-b-[2px] border-black px-2 py-2 sm:px-3 sm:py-3">
               <div className="flex flex-col gap-2 sm:gap-3 md:flex-row md:items-start md:justify-between">
                 <div className="flex min-w-0 flex-1 flex-col gap-2 sm:gap-3 md:flex-row md:items-start">
                   <div className="w-full shrink-0 md:w-64">
@@ -544,102 +519,48 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
 
                 {selectedGroup && (
                   <div className="flex shrink-0 items-center gap-1 self-end md:self-start">
-                    <button
-                      type="button"
-                      aria-label="Share group"
-                      onClick={() => {
-                        if (!selectedGroup) return;
-                        openNestedModal(setShareModalOpen);
-                      }}
-                      className="grid h-7 w-7 shrink-0 place-items-center border-2 border-black bg-white text-black"
-                    >
-                      <Share2 className="h-4 w-4 stroke-[2]" />
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Leave group"
-                      onClick={() => {
-                        if (!selectedGroup) return;
-                        openNestedModal(setLeaveModalOpen);
-                      }}
-                      className="grid h-7 w-7 shrink-0 place-items-center border-2 border-black bg-white text-black"
-                    >
-                      <LogOut className="h-4 w-4 stroke-[2]" />
-                    </button>
-                    {hasMoreActions && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            className="group relative h-7 w-7 shrink-0 overflow-hidden border-2 border-black transition-colors"
-                            aria-label="Open group actions"
-                          >
-                            <div className="absolute inset-0 bg-background transition-colors group-hover:bg-[#f6cb48] group-active:bg-[#f6cb48]" />
-                            <span className="relative flex h-full w-full items-center justify-center text-foreground">
-                              <MoreHorizontal className="h-4 w-4" />
-                            </span>
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-48">
-                          {isOwner && (
-                            <>
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  openNestedModal(setEditGroupModalOpen)
-                                }
-                              >
-                                <Pencil className="mr-2 h-4 w-4" />
-                                Edit Group
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                            </>
-                          )}
-                          {canSendInvitations && (
-                            <>
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  openNestedModal(setInviteModalOpen)
-                                }
-                              >
-                                <UserPlus className="mr-2 h-4 w-4" />
-                                Invite Members
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                            </>
-                          )}
-                          {canEditMessage && (
-                            <>
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  openNestedModal(setEditMessageModalOpen)
-                                }
-                              >
-                                <MessageSquare className="mr-2 h-4 w-4" />
-                                Edit Message
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                            </>
-                          )}
-                          {isOwner && (
-                            <DropdownMenuItem
-                              onClick={() =>
-                                openNestedModal(setDeleteModalOpen)
-                              }
-                              className="text-red-600 focus:text-red-600"
-                            >
-                              <Trash2 className="mr-2 h-4 w-4" />
-                              Delete Group
-                            </DropdownMenuItem>
-                          )}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
+                    <div className="group relative">
+                      <button
+                        type="button"
+                        aria-label="Share group"
+                        onClick={() => {
+                          if (!selectedGroup) return;
+                          openNestedModal(setShareModalOpen);
+                        }}
+                        className="grid h-7 w-7 shrink-0 place-items-center border-2 border-black bg-white text-black"
+                      >
+                        <Share2 className="h-4 w-4 stroke-[2]" />
+                      </button>
+                      <div className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 -translate-x-1/2 whitespace-nowrap border border-black bg-black px-2 py-0.5 text-[11px] text-white opacity-0 transition-opacity group-hover:opacity-100">
+                        Share group
+                      </div>
+                    </div>
+                    <div className="group relative">
+                      <button
+                        type="button"
+                        aria-label="Leave group"
+                        onClick={() => {
+                          if (!selectedGroup) return;
+                          if (selectedGroup.memberCount === 1) {
+                            openNestedModal(setDeleteModalOpen);
+                          } else {
+                            openNestedModal(setLeaveModalOpen);
+                          }
+                        }}
+                        className="grid h-7 w-7 shrink-0 place-items-center border-2 border-black bg-white text-black"
+                      >
+                        <LogOut className="h-4 w-4 stroke-[2]" />
+                      </button>
+                      <div className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 -translate-x-1/2 whitespace-nowrap border border-black bg-black px-2 py-0.5 text-[11px] text-white opacity-0 transition-opacity group-hover:opacity-100">
+                        Leave group
+                      </div>
+                    </div>
                   </div>
                 )}
               </div>
             </div>
 
-            <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden md:flex-row">
               <div className="flex w-full shrink-0 flex-col border-b-[2px] border-black bg-secondary/50 md:w-48 md:border-b-0 md:border-r-[2px]">
                 {selectedGroup && (
                   <div className="scrollbar-hide flex-1 overflow-x-auto overflow-y-hidden px-0 py-0 md:flex-1">
@@ -755,14 +676,6 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
 
       {selectedGroup && (
         <>
-          <InviteMembersModal
-            open={inviteModalOpen}
-            onOpenChange={setInviteModalOpen}
-            groupName={selectedGroup.name}
-            groupId={selectedGroup.id}
-            showSuccess={showSuccess}
-          />
-
           <ShareGroupModal
             open={shareModalOpen}
             onOpenChange={setShareModalOpen}
@@ -785,24 +698,6 @@ export function GroupPanel({ open, onOpenChange }: GroupPanelProps) {
             groupName={selectedGroup.name}
             onConfirmDelete={handleGroupDeleted}
           />
-
-          {isOwner && (
-            <EditGroupModal
-              open={editGroupModalOpen}
-              onOpenChange={setEditGroupModalOpen}
-              group={selectedGroup}
-              onUpdated={handleGroupUpdated}
-            />
-          )}
-
-          {canEditMessage && (
-            <EditGroupMessageModal
-              open={editMessageModalOpen}
-              onOpenChange={setEditMessageModalOpen}
-              group={selectedGroup}
-              onUpdated={handleMessageUpdated}
-            />
-          )}
         </>
       )}
 

--- a/src/components/groups/GroupSwitcher.tsx
+++ b/src/components/groups/GroupSwitcher.tsx
@@ -60,7 +60,7 @@ export function GroupSwitcher({
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 right-0 top-full z-30 mt-1 overflow-hidden border-2 border-[#1f1f1f] bg-white shadow-none">
+        <div className="absolute left-0 right-0 top-full z-[60] mt-1 overflow-hidden border-2 border-[#1f1f1f] bg-white shadow-none">
           <div className="scrollbar-hide max-h-52 overflow-y-auto">
             <div className="sticky top-0 z-10 bg-white px-3 pb-1 pt-3">
               <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">

--- a/src/components/groups/tabs/AboutTab.tsx
+++ b/src/components/groups/tabs/AboutTab.tsx
@@ -1,15 +1,6 @@
 'use client';
 
-import {
-  Globe,
-  Lock,
-  Eye,
-  EyeOff,
-  Users,
-  Calendar,
-  Crown,
-  MessageSquare,
-} from 'lucide-react';
+import { Users, Calendar, Crown, MessageSquare } from 'lucide-react';
 import { type Group } from '@/lib/types/group';
 
 function formatFullDate(dateStr: string): string {
@@ -72,28 +63,6 @@ export function AboutTab({ group }: AboutTabProps) {
         </h3>
 
         <div className="space-y-2.5">
-          <div className="flex items-center gap-3">
-            {group.privacy === 'PUBLIC' ? (
-              <Globe size={15} className="shrink-0 text-gray-400" />
-            ) : (
-              <Lock size={15} className="shrink-0 text-gray-400" />
-            )}
-            <span className="text-sm text-gray-600">
-              {group.privacy === 'PUBLIC' ? 'Public' : 'Private'} group
-            </span>
-          </div>
-
-          <div className="flex items-center gap-3">
-            {group.visibility === 'VISIBLE' ? (
-              <Eye size={15} className="shrink-0 text-gray-400" />
-            ) : (
-              <EyeOff size={15} className="shrink-0 text-gray-400" />
-            )}
-            <span className="text-sm text-gray-600">
-              {group.visibility === 'VISIBLE' ? 'Visible' : 'Hidden'} in search
-            </span>
-          </div>
-
           <div className="flex items-center gap-3">
             <Users size={15} className="shrink-0 text-gray-400" />
             <span className="text-sm text-gray-600">

--- a/src/components/groups/tabs/MediaTab.tsx
+++ b/src/components/groups/tabs/MediaTab.tsx
@@ -78,15 +78,6 @@ export function MediaTab({ group, onRequestModalOpen }: MediaTabProps) {
         <div className="flex h-64 flex-col items-center justify-center gap-2">
           <ImageIcon className="h-12 w-12 text-muted-foreground" />
           <p className="text-sm text-muted-foreground">No posts yet</p>
-          <Button
-            variant="outline"
-            onClick={() => {
-              onRequestModalOpen?.();
-              setAddMemoryOpen(true);
-            }}
-          >
-            Create First Post
-          </Button>
         </div>
       )}
 

--- a/src/components/map/ActionBar.tsx
+++ b/src/components/map/ActionBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Copy, Heart, Share } from 'lucide-react';
+import { Copy, Heart } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import type { MemoryWithRelations } from '@/lib/schemas';
@@ -78,17 +78,6 @@ export function ActionBar({
     }
   }, [memory.description]);
 
-  const handleShare = useCallback(async () => {
-    try {
-      const url = `${window.location.origin}/memories/${memory.id}`;
-      await navigator.clipboard.writeText(url);
-      toast.success('Link copied');
-    } catch (err) {
-      console.error('Failed to copy link:', err);
-      toast.error('Failed to copy link');
-    }
-  }, [memory.id]);
-
   const actionButtonBaseClass =
     'flex h-10 w-10 items-center justify-center border-2 border-black bg-white text-black transition-colors disabled:opacity-50';
   const textActionButtonBaseClass =
@@ -123,14 +112,6 @@ export function ActionBar({
         aria-label="Copy caption"
       >
         <Copy className="h-5 w-5" />
-      </button>
-
-      <button
-        onClick={handleShare}
-        className={actionButtonBaseClass}
-        aria-label="Share memory"
-      >
-        <Share className="h-5 w-5" />
       </button>
 
       {showReadMore && onReadMore && (

--- a/src/components/map/EraSelector.tsx
+++ b/src/components/map/EraSelector.tsx
@@ -18,11 +18,20 @@ const ERAS = [
 
 interface EraSelectorProps {
   activeEra: number | null;
+  selectedYear: number | null;
   onEraSelect: (era: number) => void;
 }
 
-export function EraSelector({ activeEra, onEraSelect }: EraSelectorProps) {
-  const label = activeEra ? `${activeEra}s` : '2020s';
+export function EraSelector({
+  activeEra,
+  selectedYear,
+  onEraSelect,
+}: EraSelectorProps) {
+  const label = selectedYear
+    ? String(selectedYear)
+    : activeEra
+      ? `${activeEra}s`
+      : '2020s';
 
   return (
     <div className="absolute bottom-10 right-[4.5rem] z-30 sm:bottom-14 sm:right-24">

--- a/src/components/map/FilterPanel.tsx
+++ b/src/components/map/FilterPanel.tsx
@@ -202,7 +202,7 @@ export function FilterPanel({
           ref={panelRef}
           aria-label="Memory filters"
           className={cn(
-            'pointer-events-auto relative flex h-[calc(100vh-5rem)] max-h-[calc(100dvh-11.5rem)] w-[calc(100vw-1rem)] max-w-none flex-col rounded-none border-[2px] border-black bg-background p-0 shadow-none transition-transform duration-300 ease-out sm:max-h-none md:h-[75vh] md:w-[70vw]',
+            'pointer-events-auto relative flex w-[calc(100vw-1rem)] max-w-none flex-col rounded-none border-[2px] border-black bg-background p-0 shadow-none transition-transform duration-300 ease-out md:w-[70vw]',
             open ? 'translate-y-0' : 'translate-y-full'
           )}
         >
@@ -270,7 +270,7 @@ export function FilterPanel({
             </div>
           </div>
 
-          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-3 sm:gap-5 sm:py-4">
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-3 pb-5 sm:gap-5 sm:py-4 sm:pb-5">
             <FilterSection label="Search">
               <div className="flex gap-2">
                 <Input

--- a/src/components/map/FilterPanel.tsx
+++ b/src/components/map/FilterPanel.tsx
@@ -365,13 +365,11 @@ export function FilterPanel({
                     )
                   }
                   options={[
-                    { label: 'All years', value: '' },
-                    ...displayedAvailableYears
-                      .slice(0, MAX_DROPDOWN_OPTIONS)
-                      .map((year) => ({
-                        label: String(year),
-                        value: String(year),
-                      })),
+                    { label: '—', value: '' },
+                    ...displayedAvailableYears.map((year) => ({
+                      label: String(year),
+                      value: String(year),
+                    })),
                   ]}
                 />
               </FilterSection>

--- a/src/components/map/FilterPanel.tsx
+++ b/src/components/map/FilterPanel.tsx
@@ -12,7 +12,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/DropdownMenu';
-import { usePanelOpenEffects } from '@/components/shared/shell/MainShellSidebarAction';
+import {
+  usePanelOpenEffects,
+  useMainShellChrome,
+} from '@/components/shared/shell/MainShellSidebarAction';
 import {
   type MemoryFilters,
   type SortOption,
@@ -62,6 +65,9 @@ export function FilterPanel({
   availableLocations,
 }: FilterPanelProps) {
   usePanelOpenEffects(open);
+
+  const shellChrome = useMainShellChrome();
+  const sidebarOpen = shellChrome?.sidebarOpen ?? false;
 
   const [btnAnim, setBtnAnim] = useState<
     'idle' | 'bob-open' | 'submerged' | 'bounce-back'
@@ -172,30 +178,51 @@ export function FilterPanel({
             open ? 'translate-y-0' : 'translate-y-full'
           )}
         >
-          <button
-            type="button"
-            aria-label={open ? 'Close filters' : 'Open filters'}
-            onClick={handleTabClick}
+          {/*
+           * Positioning wrapper: owns `left` + X-translation via CSS vars.
+           * This layer is NEVER animated, so the X-offset survives every
+           * click → re-render → keyframe cycle without jumping.
+           */}
+          <div
             className={cn(
-              'pointer-events-auto absolute -top-[4rem] h-[5.5rem] w-12 flex-col items-center justify-start gap-1 border-[2px] border-b-0 border-black bg-[#f6cb48] pt-2 text-black',
-              open || btnAnim === 'submerged' ? 'hidden' : 'flex',
-              btnAnim === 'bob-open' && 'animate-btn-bob-open',
-              btnAnim === 'bounce-back' && 'animate-btn-bounce-back'
+              'pointer-events-none absolute -top-[4rem]',
+              // Visibility mirrors the old button logic, now on the wrapper
+              open || btnAnim === 'submerged'
+                ? 'hidden'
+                : sidebarOpen
+                  ? 'hidden sm:block'
+                  : 'block'
             )}
             style={{
-              left: 100,
+              left: 74,
               transform:
                 'translateX(max(0px, calc(var(--map-left-offset, 0px) - var(--panel-left, 0px))))',
             }}
           >
-            <FunnelIcon
-              size={22}
-              weight="duotone"
-              className="filter-panel-icon mt-1"
-              style={{ flexShrink: 0 }}
-              aria-hidden
-            />
-          </button>
+            {/*
+             * Inner button: owns click, aria, and Y-only animation classes.
+             * No inline transform here — keyframes only set translateY so
+             * they never clobber the wrapper's translateX.
+             */}
+            <button
+              type="button"
+              aria-label={open ? 'Close filters' : 'Open filters'}
+              onClick={handleTabClick}
+              className={cn(
+                'pointer-events-auto flex h-[5.5rem] w-12 flex-col items-center justify-start gap-1 border-[2px] border-b-0 border-black bg-[#f6cb48] pt-2 text-black',
+                btnAnim === 'bob-open' && 'animate-btn-bob-open',
+                btnAnim === 'bounce-back' && 'animate-btn-bounce-back'
+              )}
+            >
+              <FunnelIcon
+                size={22}
+                weight="duotone"
+                className="filter-panel-icon mt-1"
+                style={{ flexShrink: 0 }}
+                aria-hidden
+              />
+            </button>
+          </div>
           <div className="flex items-center justify-between gap-3 border-b-[2px] border-b-black bg-[#f6cb48] px-3 py-2 text-black">
             <p className="truncate text-base font-medium tracking-[0.01em] sm:text-lg">
               Filter Memories

--- a/src/components/map/FilterPanel.tsx
+++ b/src/components/map/FilterPanel.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { X, RotateCcw, ChevronDown } from 'lucide-react';
 import { FunnelIcon } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/Input';
+import { useCurrentUser } from '@/lib/hooks/useCurrentUser';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,7 +21,6 @@ import {
   type MemoryFilters,
   type SortOption,
   type VisibilityFilter,
-  type GroupFilterOption,
   type LocationFilterOption,
   DEFAULT_FILTERS,
 } from './filter-memory-types';
@@ -32,7 +32,6 @@ interface FilterPanelProps {
   onFiltersChange: (filters: MemoryFilters) => void;
   availableTags: string[];
   availableYears: number[];
-  availableGroups: GroupFilterOption[];
   availableLocations: LocationFilterOption[];
 }
 
@@ -49,9 +48,8 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 const VISIBILITY_OPTIONS: { value: VisibilityFilter; label: string }[] = [
   { value: 'ALL', label: 'All' },
   { value: 'PUBLIC', label: 'Public' },
-  { value: 'BATCH_ONLY', label: 'Batch' },
   { value: 'PROGRAM_ONLY', label: 'Program' },
-  { value: 'GROUP_ONLY', label: 'Group' },
+  { value: 'BATCH_ONLY', label: 'Batch' },
 ];
 
 export function FilterPanel({
@@ -61,7 +59,6 @@ export function FilterPanel({
   onFiltersChange,
   availableTags,
   availableYears,
-  availableGroups,
   availableLocations,
 }: FilterPanelProps) {
   usePanelOpenEffects(open);
@@ -69,9 +66,24 @@ export function FilterPanel({
   const shellChrome = useMainShellChrome();
   const sidebarOpen = shellChrome?.sidebarOpen ?? false;
 
+  const { data: currentUserData } = useCurrentUser();
+  const userBatchYear =
+    currentUserData?.data?.programBatch?.batch?.year ?? null;
+  const currentYear = new Date().getFullYear();
+
+  const displayedAvailableYears = useMemo(() => {
+    if (filters.visibility === 'BATCH_ONLY' && userBatchYear !== null) {
+      return availableYears.filter(
+        (year) => year >= userBatchYear && year <= currentYear
+      );
+    }
+    return availableYears;
+  }, [availableYears, filters.visibility, userBatchYear, currentYear]);
+
   const [btnAnim, setBtnAnim] = useState<
     'idle' | 'bob-open' | 'submerged' | 'bounce-back'
   >('idle');
+  const [resetSuccess, setResetSuccess] = useState(false);
   const prevOpenRef = useRef(open);
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
@@ -80,6 +92,22 @@ export function FilterPanel({
     undefined
   );
   const panelRef = useRef<HTMLElement | null>(null);
+
+  const [localSearch, setLocalSearch] = useState(filters.searchQuery);
+
+  useEffect(() => {
+    setLocalSearch(filters.searchQuery);
+  }, [filters.searchQuery]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (localSearch !== filters.searchQuery) {
+        update('searchQuery', localSearch);
+      }
+    }, 300);
+    return () => clearTimeout(handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localSearch]);
 
   // Synchronously mark button as submerged before paint so there's no flash
   // when the panel closes and the button re-enters the DOM.
@@ -230,17 +258,6 @@ export function FilterPanel({
             <div className="flex shrink-0 items-center gap-1">
               <button
                 type="button"
-                aria-label="Reset filters"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onFiltersChange(DEFAULT_FILTERS);
-                }}
-                className="grid h-7 w-7 shrink-0 place-items-center border-2 border-black bg-white text-black"
-              >
-                <RotateCcw className="h-4 w-4 stroke-[2]" />
-              </button>
-              <button
-                type="button"
                 aria-label="Close filters panel"
                 onClick={(event) => {
                   event.stopPropagation();
@@ -259,15 +276,23 @@ export function FilterPanel({
                 <Input
                   type="text"
                   placeholder="Search title, description, location, tags..."
-                  value={filters.searchQuery}
-                  onChange={(e) => update('searchQuery', e.target.value)}
+                  value={localSearch}
+                  onChange={(e) => setLocalSearch(e.target.value)}
                   className="flex-1 !rounded-none border-2 border-black bg-card py-3 pl-5 pr-8 text-sm text-foreground placeholder:text-muted-foreground focus:border-black focus:outline-none focus:ring-1 focus:ring-skolaroid-blue"
                 />
                 <button
                   type="button"
                   aria-label="Reset filters"
-                  onClick={() => onFiltersChange(DEFAULT_FILTERS)}
-                  className="grid h-10 shrink-0 place-items-center border-2 border-black bg-white px-2 text-xs font-medium text-black hover:bg-[#fff3bf]"
+                  onClick={(e) => {
+                    onFiltersChange(DEFAULT_FILTERS);
+                    setResetSuccess(true);
+                    e.currentTarget.blur();
+                    setTimeout(() => setResetSuccess(false), 800);
+                  }}
+                  className={cn(
+                    'grid h-10 shrink-0 place-items-center border-2 border-black bg-white px-2 text-xs font-medium text-black transition-all duration-300 active:scale-95 active:bg-[#fff3bf]/50',
+                    resetSuccess ? 'bg-white' : 'hover:bg-[#fff3bf]'
+                  )}
                 >
                   <RotateCcw className="h-4 w-4 stroke-[2]" />
                 </button>
@@ -324,9 +349,10 @@ export function FilterPanel({
               )}
             </FilterSection>
 
-            <div className="grid gap-4 sm:grid-cols-3">
+            <div className="grid gap-4 sm:grid-cols-2">
               <FilterSection label="Year">
                 <FilterDropdown
+                  side="top"
                   value={
                     filters.selectedYear === null
                       ? ''
@@ -340,7 +366,7 @@ export function FilterPanel({
                   }
                   options={[
                     { label: 'All years', value: '' },
-                    ...availableYears
+                    ...displayedAvailableYears
                       .slice(0, MAX_DROPDOWN_OPTIONS)
                       .map((year) => ({
                         label: String(year),
@@ -350,26 +376,9 @@ export function FilterPanel({
                 />
               </FilterSection>
 
-              <FilterSection label="Group">
-                <FilterDropdown
-                  value={filters.selectedGroupId ?? ''}
-                  onChange={(value) =>
-                    update('selectedGroupId', value === '' ? null : value)
-                  }
-                  options={[
-                    { label: 'All groups', value: '' },
-                    ...availableGroups
-                      .slice(0, MAX_DROPDOWN_OPTIONS)
-                      .map((group) => ({
-                        label: group.name,
-                        value: group.id,
-                      })),
-                  ]}
-                />
-              </FilterSection>
-
               <FilterSection label="Location">
                 <FilterDropdown
+                  side="top"
                   value={filters.selectedLocationId ?? ''}
                   onChange={(value) =>
                     update('selectedLocationId', value === '' ? null : value)
@@ -441,10 +450,12 @@ function FilterDropdown({
   value,
   onChange,
   options,
+  side = 'bottom',
 }: {
   value: string;
   onChange: (value: string) => void;
   options: Array<{ label: string; value: string }>;
+  side?: 'top' | 'bottom';
 }) {
   const selectedLabel =
     options.find((opt) => opt.value === value)?.label || 'Select...';
@@ -465,7 +476,7 @@ function FilterDropdown({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        side="bottom"
+        side={side}
         align="start"
         className="z-[100] w-[var(--radix-dropdown-menu-trigger-width)] rounded-none border-2 border-[#2d2d2d] bg-[#fff4fb] p-0.5 shadow-none"
       >

--- a/src/components/map/MapComponent.tsx
+++ b/src/components/map/MapComponent.tsx
@@ -483,7 +483,10 @@ export function MapComponent({
         return;
       }
 
-      const memoryEra = getEraFromBatchTag(memory.tags ?? [], memory.createdAt);
+      const memoryEra = getEraFromBatchTag(
+        memory.tags ?? [],
+        memory.memoryDate || memory.createdAt
+      );
       const needsEraSwitch = memoryEra !== activeMapEra;
 
       const targetLng = memory.location.longitude;
@@ -842,7 +845,7 @@ export function MapComponent({
     // Switch era if needed
     const memoryEra = getEraFromBatchTag(
       targetMemory.tags ?? [],
-      targetMemory.createdAt
+      targetMemory.memoryDate || targetMemory.createdAt
     );
 
     if (memoryEra !== activeMapEra) {

--- a/src/components/map/MapComponent.tsx
+++ b/src/components/map/MapComponent.tsx
@@ -34,7 +34,7 @@ import {
   type MemoryWithCoordinates,
 } from '@/lib/hooks/useAllMemoriesWithCoordinates';
 import { useLocations } from '@/lib/hooks/useLocations';
-import { useUserGroups } from '@/lib/hooks/useUserGroups';
+
 import { LANDMARKS, type Landmark } from '@/lib/constants/landmarks';
 import { getPrimaryMemoryMediaURL } from '@/lib/memory-media';
 import type {
@@ -50,7 +50,6 @@ import { FilterPanel } from './FilterPanel';
 import { MemoryLoadingIndicator } from '@/components/shared/MemoryLoadingIndicator';
 import type {
   MemoryFilters,
-  GroupFilterOption,
   LocationFilterOption,
 } from './filter-memory-types';
 import {
@@ -95,7 +94,6 @@ const CAMERA_ANIMATION = {
 
 const DEFAULT_MAP_CENTER: [number, number] = [123.8986, 10.3224];
 const DEFAULT_MAP_ZOOM = 17;
-const EMPTY_USER_GROUPS: { id: string; name: string }[] = [];
 
 interface MapComponentProps {
   activeEraFromUrl: number;
@@ -229,21 +227,12 @@ export function MapComponent({
   const { data: creatorMemoriesData, isLoading: creatorMemoriesLoading } =
     useMemoriesByCreator(currentUserId);
   const { data: locationsData } = useLocations();
-  const { data: userGroupsData } = useUserGroups();
-  const userGroups = userGroupsData ?? EMPTY_USER_GROUPS;
+
   const showFirstMemoryPrompt =
     !!currentUserData?.data &&
     !creatorMemoriesLoading &&
     creatorMemoriesData?.data?.length === 0 &&
     !addMemoryOpen;
-
-  const availableGroups = useMemo<GroupFilterOption[]>(
-    () =>
-      userGroups
-        .map((group) => ({ id: group.id, name: group.name }))
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [userGroups]
-  );
 
   const eraFilteredMemories = useMemo(
     () => filterMemoriesByEra(memories, activeMapEra),
@@ -276,21 +265,35 @@ export function MapComponent({
 
   const displayedMemories = sortedMemories;
 
+  const visibilityFilteredMemories = useMemo(() => {
+    return eraFilteredMemories.filter((memory) => {
+      if (
+        filters.visibility !== 'ALL' &&
+        memory.visibility !== filters.visibility
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [eraFilteredMemories, filters.visibility]);
+
   const availableTags = useMemo(
     () =>
       Array.from(
         new Set(
-          eraFilteredMemories.flatMap((m) => m.tags?.map((t) => t.name) ?? [])
+          visibilityFilteredMemories.flatMap(
+            (m) => m.tags?.map((t) => t.name) ?? []
+          )
         )
       ).sort(),
-    [eraFilteredMemories]
+    [visibilityFilteredMemories]
   );
 
   const availableYears = useMemo(
     () =>
       Array.from(
         new Set(
-          eraFilteredMemories.map((m) => {
+          visibilityFilteredMemories.map((m) => {
             const memoryDateValue = (m as { memoryDate?: string }).memoryDate;
             const date = memoryDateValue
               ? new Date(memoryDateValue)
@@ -299,22 +302,19 @@ export function MapComponent({
           })
         )
       ).sort((a, b) => b - a),
-    [eraFilteredMemories]
+    [visibilityFilteredMemories]
   );
 
   const availableLocations = useMemo<LocationFilterOption[]>(() => {
     const locationIdsInEra = new Set(
-      eraFilteredMemories
+      visibilityFilteredMemories
         .map((memory) => (memory.location as { id?: string } | undefined)?.id)
         .filter((id): id is string => Boolean(id))
     );
 
     if (locationsData?.data?.length) {
       return locationsData.data
-        .filter(
-          (location) =>
-            locationIdsInEra.size === 0 || locationIdsInEra.has(location.id)
-        )
+        .filter((location) => locationIdsInEra.has(location.id))
         .map((location) => ({
           id: location.id,
           name: location.buildingName,
@@ -324,7 +324,7 @@ export function MapComponent({
 
     const fallbackLocations = new Map<string, LocationFilterOption>();
 
-    for (const memory of eraFilteredMemories) {
+    for (const memory of visibilityFilteredMemories) {
       const location = memory.location as
         | { id?: string; buildingName: string }
         | undefined;
@@ -340,7 +340,7 @@ export function MapComponent({
     return Array.from(fallbackLocations.values()).sort((a, b) =>
       a.name.localeCompare(b.name)
     );
-  }, [eraFilteredMemories, locationsData]);
+  }, [visibilityFilteredMemories, locationsData]);
 
   // Keep a stable ref for the click handler so detached roots always call the latest version
   const handleClickRef = useRef<(landmark: Landmark) => void>(() => {});
@@ -1142,7 +1142,6 @@ export function MapComponent({
             onFiltersChange={onFiltersChange}
             availableTags={availableTags}
             availableYears={availableYears}
-            availableGroups={availableGroups}
             availableLocations={availableLocations}
           />
 

--- a/src/components/map/MapComponent.tsx
+++ b/src/components/map/MapComponent.tsx
@@ -99,6 +99,7 @@ interface MapComponentProps {
   activeEraFromUrl: number;
   filters: MemoryFilters;
   onFiltersChange: (filters: MemoryFilters) => void;
+  onEraChange: (era: number) => void;
   onMemoryDetailOpenRequest?: () => Promise<void> | void;
   onMemoryDetailOpenStateChange?: (open: boolean) => void;
 }
@@ -107,6 +108,7 @@ export function MapComponent({
   activeEraFromUrl,
   filters,
   onFiltersChange,
+  onEraChange,
   onMemoryDetailOpenRequest,
   onMemoryDetailOpenStateChange,
 }: MapComponentProps) {
@@ -239,6 +241,25 @@ export function MapComponent({
     [memories, activeMapEra]
   );
 
+  // Primary scope: year overrides era completely, filtering from the global set.
+  const scopedMemories = useMemo(() => {
+    if (filters.selectedYear) {
+      return memories.filter((m) => {
+        if (
+          m.moderationStatus === 'REJECTED' ||
+          m.moderationStatus === 'REMOVED'
+        )
+          return false;
+        const dateVal = (m as { memoryDate?: string }).memoryDate;
+        const year = dateVal
+          ? new Date(dateVal).getFullYear()
+          : new Date(m.createdAt ?? Date.now()).getFullYear();
+        return year === filters.selectedYear;
+      });
+    }
+    return eraFilteredMemories;
+  }, [memories, eraFilteredMemories, filters.selectedYear]);
+
   const selectedMemoryIndex = useMemo(
     () =>
       selectedMemory
@@ -254,8 +275,8 @@ export function MapComponent({
       : null;
 
   const tagFilteredMemories = useMemo(
-    () => applyMemoryFilters(eraFilteredMemories, filters),
-    [eraFilteredMemories, filters]
+    () => applyMemoryFilters(scopedMemories, filters),
+    [scopedMemories, filters]
   );
 
   const sortedMemories = useMemo(
@@ -266,7 +287,7 @@ export function MapComponent({
   const displayedMemories = sortedMemories;
 
   const visibilityFilteredMemories = useMemo(() => {
-    return eraFilteredMemories.filter((memory) => {
+    return scopedMemories.filter((memory) => {
       if (
         filters.visibility !== 'ALL' &&
         memory.visibility !== filters.visibility
@@ -275,7 +296,7 @@ export function MapComponent({
       }
       return true;
     });
-  }, [eraFilteredMemories, filters.visibility]);
+  }, [scopedMemories, filters.visibility]);
 
   const availableTags = useMemo(
     () =>
@@ -289,20 +310,31 @@ export function MapComponent({
     [visibilityFilteredMemories]
   );
 
+  // Years derive from visibility-gated global memories (not era-restricted).
   const availableYears = useMemo(
     () =>
       Array.from(
         new Set(
-          visibilityFilteredMemories.map((m) => {
-            const memoryDateValue = (m as { memoryDate?: string }).memoryDate;
-            const date = memoryDateValue
-              ? new Date(memoryDateValue)
-              : new Date(m.createdAt ?? Date.now());
-            return date.getFullYear();
-          })
+          memories
+            .filter(
+              (m) =>
+                m.moderationStatus !== 'REJECTED' &&
+                m.moderationStatus !== 'REMOVED'
+            )
+            .filter((m) => {
+              if (filters.visibility === 'ALL') return true;
+              return m.visibility === filters.visibility;
+            })
+            .map((m) => {
+              const memoryDateValue = (m as { memoryDate?: string }).memoryDate;
+              const date = memoryDateValue
+                ? new Date(memoryDateValue)
+                : new Date(m.createdAt ?? Date.now());
+              return date.getFullYear();
+            })
         )
       ).sort((a, b) => b - a),
-    [visibilityFilteredMemories]
+    [memories, filters.visibility]
   );
 
   const availableLocations = useMemo<LocationFilterOption[]>(() => {
@@ -1107,7 +1139,8 @@ export function MapComponent({
 
           <EraSelector
             activeEra={activeMapEra}
-            onEraSelect={(era) => setActiveMapEra(era)}
+            selectedYear={filters.selectedYear}
+            onEraSelect={onEraChange}
           />
           <AddMemoryButton onClick={() => openAddMemoryModal()} />
 

--- a/src/components/map/MemoryNotebookPageContent.tsx
+++ b/src/components/map/MemoryNotebookPageContent.tsx
@@ -317,6 +317,18 @@ export const MemoryNotebookPageContent = memo(
             <p className="text-normal text-black">{authorName}</p>
             <div className="flex items-center gap-1 text-xs text-muted-foreground">
               <span>{visibilityDisplay.label}</span>
+              {memory.memoryDate && (
+                <>
+                  <span>·</span>
+                  <span>
+                    {new Date(memory.memoryDate).toLocaleDateString('en-US', {
+                      month: 'long',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </span>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/lib/hooks/useAllMemoriesWithCoordinates.ts
+++ b/src/lib/hooks/useAllMemoriesWithCoordinates.ts
@@ -27,6 +27,13 @@ export function useAllMemoriesWithCoordinates() {
       if (!res.ok) throw new Error('Failed to fetch memories');
       return res.json() as Promise<AllMemoriesResponse>;
     },
+    select: (data) => ({
+      ...data,
+      data: data.data.map((m) => ({
+        ...m,
+        memoryDate: m.memoryDate ?? m.createdAt ?? null,
+      })),
+    }),
     staleTime: 5 * 60 * 1000,
     refetchOnMount: 'always',
     refetchOnWindowFocus: 'always',

--- a/src/lib/memory-view-filters.ts
+++ b/src/lib/memory-view-filters.ts
@@ -120,7 +120,12 @@ export function filterMemoriesByEra(
       return false;
     }
 
-    return getEraFromBatchTag(memory.tags ?? [], memory.createdAt) === era;
+    return (
+      getEraFromBatchTag(
+        memory.tags ?? [],
+        memory.memoryDate || memory.createdAt
+      ) === era
+    );
   });
 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -328,6 +328,7 @@ export interface MemoryWithRelations {
   moderationStatus?: ModerationStatus;
   creatorId?: string | null;
   privateGroupId?: string | null;
+  memoryDate?: string | null;
   createdAt?: string;
   tags?: { id: string; name: string }[];
   location?: { buildingName: string };

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -329,6 +329,7 @@ export interface MemoryWithRelations {
   creatorId?: string | null;
   privateGroupId?: string | null;
   createdAt?: string;
+  memoryDate?: string | Date | null;
   tags?: { id: string; name: string }[];
   location?: { buildingName: string };
   creator?: {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -330,7 +330,6 @@ export interface MemoryWithRelations {
   privateGroupId?: string | null;
   memoryDate?: string | null;
   createdAt?: string;
-  memoryDate?: string | Date | null;
   tags?: { id: string; name: string }[];
   location?: { buildingName: string };
   creator?: {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,7 +11,7 @@ export function cn(...inputs: ClassValue[]) {
  */
 export function getEraFromBatchTag(
   tags: { name: string }[],
-  fallbackDate?: string | null
+  fallbackDate?: string | Date | null
 ): number {
   for (const tag of tags) {
     const match = tag.name.match(/^batch-(\d{4})$/i);
@@ -20,7 +20,7 @@ export function getEraFromBatchTag(
     }
   }
   if (fallbackDate) {
-    return Math.floor(new Date(fallbackDate).getFullYear() / 10) * 10;
+    return Math.floor(new Date(fallbackDate as string).getFullYear() / 10) * 10;
   }
   return 2020;
 }


### PR DESCRIPTION
- Refactored filter icon as a child of the map container with corrected positioning and hover state fixes
- Updated visibility hierarchy (swapped Batch/Program, removed Groups), with dynamic era alignment when filtered year falls outside the selected era
- Fixed upload memory flow: photos required before proceeding, caption made mandatory, attachment count reflected in privacy section, and language field removed
- Cleaned up memory detail view by removing the share button and ensuring memory date is visible
- Improved group panel by removing redundant UI elements (choose privacy, visibility, three-dot menu), adding tooltips, and handling single-member group deletion on leave
- Added group-specific filter customization: removes visibility section and Group dropdown, repositions Year and Location to the top row when a group is active on the map